### PR TITLE
feat: add event handlers for shoutout create and receive

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -100,6 +100,8 @@ type Client struct {
 	onEventChannelCharityCampaignStop                       func(event EventChannelCharityCampaignStop)
 	onEventChannelShieldModeBegin                           func(event EventChannelShieldModeBegin)
 	onEventChannelShieldModeEnd                             func(event EventChannelShieldModeEnd)
+	onEventChannelShoutoutCreate                            func(event EventChannelShoutoutCreate)
+	onEventChannelShoutoutReceive                           func(event EventChannelShoutoutReceive)
 }
 
 func NewClient() *Client {
@@ -363,6 +365,10 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelShieldModeBegin, *event)
 	case *EventChannelShieldModeEnd:
 		callFunc(c.onEventChannelShieldModeEnd, *event)
+	case *EventChannelShoutoutCreate:
+		callFunc(c.onEventChannelShoutoutCreate, *event)
+	case *EventChannelShoutoutReceive:
+		callFunc(c.onEventChannelShoutoutReceive, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -590,4 +596,12 @@ func (c *Client) OnEventChannelShieldModeBegin(callback func(event EventChannelS
 
 func (c *Client) OnEventChannelShieldModeEnd(callback func(event EventChannelShieldModeEnd)) {
 	c.onEventChannelShieldModeEnd = callback
+}
+
+func (c *Client) OnEventChannelShoutoutCreate(callback func(event EventChannelShoutoutCreate)) {
+	c.onEventChannelShoutoutCreate = callback
+}
+
+func (c *Client) OnEventChannelShoutoutReceive(callback func(event EventChannelShoutoutReceive)) {
+	c.onEventChannelShoutoutReceive = callback
 }

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -513,3 +513,23 @@ func TestEventChannelShieldModeEnd(t *testing.T) {
 		})
 	}, twitch.SubChannelShieldModeEnd)
 }
+
+func TestEventChannelShoutoutCreate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelShoutoutCreate(func(event twitch.EventChannelShoutoutCreate) {
+			close(ch)
+		})
+	}, twitch.SubChannelShoutoutCreate)
+}
+
+func TestEventChannelShoutoutReceive(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelShoutoutReceive(func(event twitch.EventChannelShoutoutReceive) {
+			close(ch)
+		})
+	}, twitch.SubChannelShoutoutReceive)
+}

--- a/events.go
+++ b/events.go
@@ -440,3 +440,27 @@ type EventChannelShieldModeBegin struct {
 }
 
 type EventChannelShieldModeEnd EventChannelShieldModeBegin
+
+type EventChannelShoutoutCreate struct {
+	Broadcaster
+	Moderator
+
+	ToBroadcasterUserId    string    `json:"to_broadcaster_user_id"`
+	ToBroadcasterUserLogin string    `json:"to_broadcaster_user_login"`
+	ToBroadcasterUserName  string    `json:"to_broadcaster_user_name"`
+	StartedAt              time.Time `json:"started_at"`
+	ViewerCount            int       `json:"viewer_count"`
+	CooldownEndsAt         time.Time `json:"cooldown_ends_at"`
+	TargetCooldownEndsAt   time.Time `json:"target_cooldown_ends_at"`
+}
+
+type EventChannelShoutoutReceive struct {
+	Broadcaster
+	Moderator
+
+	FromBroadcasterUserId    string    `json:"from_broadcaster_user_id"`
+	FromBroadcasterUserLogin string    `json:"from_broadcaster_user_login"`
+	FromBroadcasterUserName  string    `json:"from_broadcaster_user_name"`
+	ViewerCount              int       `json:"viewer_count"`
+	StartedAt                time.Time `json:"started_at"`
+}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -71,6 +71,9 @@ var (
 	SubChannelShieldModeBegin EventSubscription = "channel.shield_mode.begin"
 	SubChannelShieldModeEnd   EventSubscription = "channel.shield_mode.end"
 
+	SubChannelShoutoutCreate  EventSubscription = "channel.shoutout.create"
+	SubChannelShoutoutReceive EventSubscription = "channel.shoutout.receive"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -243,6 +246,14 @@ var (
 		SubChannelShieldModeEnd: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelShieldModeEnd](),
+		},
+		SubChannelShoutoutCreate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelShoutoutCreate](),
+		},
+		SubChannelShoutoutReceive: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelShoutoutReceive](),
 		},
 	}
 )

--- a/testEvents.json
+++ b/testEvents.json
@@ -946,5 +946,31 @@
         "moderator_user_name": "ParticularlyParticular123",
         "moderator_user_login": "particularlyparticular123",
         "ended_at": "2022-07-27T01:30:23.17106713Z"
+    },
+    "channel.shoutout.create": {
+        "broadcaster_user_id": "12345",
+        "broadcaster_user_name": "SimplySimple",
+        "broadcaster_user_login": "simplysimple",
+        "moderator_user_id": "98765",
+        "moderator_user_name": "ParticularlyParticular123",
+        "moderator_user_login": "particularlyparticular123",
+        "to_broadcaster_user_id": "626262",
+        "to_broadcaster_user_name": "SandySanderman",
+        "to_broadcaster_user_login": "sandysanderman",
+        "started_at": "2022-07-26T17:00:03.17106713Z",
+        "viewer_count": 860,
+        "cooldown_ends_at": "2022-07-26T17:02:03.17106713Z",
+        "target_cooldown_ends_at": "2022-07-26T18:00:03.17106713Z"
+    },
+    
+    "channel.shoutout.receive": {
+        "broadcaster_user_id": "626262",
+        "broadcaster_user_name": "SandySanderman",
+        "broadcaster_user_login": "sandysanderman",
+        "from_broadcaster_user_id": "12345",
+        "from_broadcaster_user_name": "SimplySimple",
+        "from_broadcaster_user_login": "simplysimple",
+        "viewer_count": 860,
+        "started_at": "2022-07-26T17:00:03.17106713Z"
     }
 }


### PR DESCRIPTION
This commit adds event handlers for the `EventChannelShoutoutCreate` and EventChannelShoutoutReceive` events.

Closes #5