### PR TITLE
Add channel.moderate v2

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -102,6 +102,7 @@ type Client struct {
 	onEventChannelShieldModeEnd                             func(event EventChannelShieldModeEnd)
 	onEventChannelShoutoutCreate                            func(event EventChannelShoutoutCreate)
 	onEventChannelShoutoutReceive                           func(event EventChannelShoutoutReceive)
+	onEventChannelModerate                                  func(event EventChannelModerate)
 }
 
 func NewClient() *Client {
@@ -369,6 +370,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelShoutoutCreate, *event)
 	case *EventChannelShoutoutReceive:
 		callFunc(c.onEventChannelShoutoutReceive, *event)
+	case *EventChannelModerate:
+		callFunc(c.onEventChannelModerate, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -604,4 +607,8 @@ func (c *Client) OnEventChannelShoutoutCreate(callback func(event EventChannelSh
 
 func (c *Client) OnEventChannelShoutoutReceive(callback func(event EventChannelShoutoutReceive)) {
 	c.onEventChannelShoutoutReceive = callback
+}
+
+func (c *Client) OnEventChannelModerate(callback func(event EventChannelModerate)) {
+	c.onEventChannelModerate = callback
 }

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -533,3 +533,13 @@ func TestEventChannelShoutoutReceive(t *testing.T) {
 		})
 	}, twitch.SubChannelShoutoutReceive)
 }
+
+func TestEventChannelModerate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelModerate(func(event twitch.EventChannelModerate) {
+			close(ch)
+		})
+	}, twitch.SubChannelModerate)
+}

--- a/events.go
+++ b/events.go
@@ -23,6 +23,52 @@ type Moderator struct {
 	ModeratorUserName  string `json:"moderator_user_name"`
 }
 
+type SourceBroadcaster struct {
+	SourceBroadcasterUserId    string `json:"source_broadcaster_user_id"`
+	SourceBroadcasterUserLogin string `json:"source_broadcaster_user_login"`
+	SourceBroadcasterUserName  string `json:"source_broadcaster_user_name"`
+}
+
+type Ban struct {
+	User
+	Reason *string `json:"reason,omitempty"`
+}
+
+type Timeout struct {
+	Ban
+	ExpiresAt time.Time `json:"expires_at"`
+}
+
+type Raid struct {
+	User
+	ViewerCount int `json:"viewer_count"`
+}
+
+type DeletedMessage struct {
+	User
+	MessageId   string `json:"message_id"`
+	MessageBody string `json:"message_body"`
+}
+
+type AutomodTerms struct {
+	Action      string   `json:"action"`
+	List        string   `json:"list"`
+	Terms       []string `json:"terms"`
+	FromAutomod bool     `json:"from_automod"`
+}
+
+type UnbanRequest struct {
+	User
+	IsApproved       bool   `json:"is_approved"`
+	ModeratorMessage string `json:"moderator_message"`
+}
+
+type Warning struct {
+	User
+	Reason         string   `json:"reason"`
+	ChatRulesCited []string `json:"chat_rules_cited"`
+}
+
 type EventChannelUpdate struct {
 	Broadcaster
 
@@ -463,4 +509,33 @@ type EventChannelShoutoutReceive struct {
 	FromBroadcasterUserName  string    `json:"from_broadcaster_user_name"`
 	ViewerCount              int       `json:"viewer_count"`
 	StartedAt                time.Time `json:"started_at"`
+}
+
+type EventChannelModerate struct {
+	Broadcaster
+	SourceBroadcaster
+	Moderator
+
+	Action              string          `json:"action"`
+	Followers           *int            `json:"followers,omitempty"`
+	Slow                *int            `json:"slow,omitempty"`
+	Vip                 *User           `json:"vip,omitempty"`
+	Unvip               *User           `json:"unvip,omitempty"`
+	Mod                 *User           `json:"mod,omitempty"`
+	Unmod               *User           `json:"unmod,omitempty"`
+	Ban                 *Ban            `json:"ban,omitempty"`
+	Unban               *User           `json:"unban,omitempty"`
+	Timeout             *Timeout        `json:"timeout,omitempty"`
+	Untimeout           *User           `json:"untimeout,omitempty"`
+	Raid                *Raid           `json:"raid,omitempty"`
+	Unraid              *User           `json:"unraid,omitempty"`
+	Delete              *DeletedMessage `json:"delete,omitempty"`
+	AutomodTerms        *AutomodTerms   `json:"automod_terms,omitempty"`
+	UnbanRequest        *UnbanRequest   `json:"unban_request,omitempty"`
+	Warn                *Warning        `json:"warn,omitempty"`
+	SharedChatBan       *Ban            `json:"shared_chat_ban,omitempty"`
+	SharedChatUnban     *User           `json:"shared_chat_unban,omitempty"`
+	SharedChatTimeout   *Timeout        `json:"shared_chat_timeout,omitempty"`
+	SharedChatuntimeout *User           `json:"shared_chat_untimeout,omitempty"`
+	SharedChatDelete    *DeletedMessage `json:"shared_chat_delete,omitempty"`
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -74,6 +74,8 @@ var (
 	SubChannelShoutoutCreate  EventSubscription = "channel.shoutout.create"
 	SubChannelShoutoutReceive EventSubscription = "channel.shoutout.receive"
 
+	SubChannelModerate EventSubscription = "channel.moderate"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -254,6 +256,10 @@ var (
 		SubChannelShoutoutReceive: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelShoutoutReceive](),
+		},
+		SubChannelModerate: {
+			Version:  "2",
+			EventGen: zeroPtrGen[EventChannelModerate](),
 		},
 	}
 )

--- a/testEvents.json
+++ b/testEvents.json
@@ -962,7 +962,6 @@
         "cooldown_ends_at": "2022-07-26T17:02:03.17106713Z",
         "target_cooldown_ends_at": "2022-07-26T18:00:03.17106713Z"
     },
-    
     "channel.shoutout.receive": {
         "broadcaster_user_id": "626262",
         "broadcaster_user_name": "SandySanderman",
@@ -972,5 +971,43 @@
         "from_broadcaster_user_login": "simplysimple",
         "viewer_count": 860,
         "started_at": "2022-07-26T17:00:03.17106713Z"
+    },
+    "channel.moderate": {
+        "broadcaster_user_id": "423374343",
+        "broadcaster_user_login": "glowillig",
+        "broadcaster_user_name": "glowillig",
+        "source_broadcaster_user_id": "41292030",
+        "source_broadcaster_user_login": "adflynn404",
+        "source_broadcaster_user_name": "adflynn404",
+        "moderator_user_id": "424596340",
+        "moderator_user_login": "quotrok",
+        "moderator_user_name": "quotrok",
+        "action": "warn",
+        "followers": null,
+        "slow": null,
+        "vip": null,
+        "unvip": null,
+        "warn": {
+            "user_id": "141981764",
+            "user_login": "twitchdev",
+            "user_name": "TwitchDev",
+            "reason": "cut it out",
+            "chat_rules_cited": null
+        },
+        "unmod": null,
+        "ban": null,
+        "unban": null,
+        "timeout": null,
+        "untimeout": null,
+        "raid": null,
+        "unraid": null,
+        "delete": null,
+        "automod_terms": null,
+        "unban_request": null,
+        "shared_chat_ban": null,
+        "shared_chat_unban": null,
+        "shared_chat_timeout": null,
+        "shared_chat_untimeout": null,
+        "shared_chat_delete": null
     }
 }


### PR DESCRIPTION
Added support for [channel.moderate v2](https://dev.twitch.tv/docs/eventsub/eventsub-reference/#channel-moderate-event-v2).
Used an example from Twitch docs as a test.

I am migrating from pubsub to eventsub and if this project works well long term (does not leak memory or crash) then I'll add more events in the future.