### PR TITLE
Add Chat, Shared Chat, AutoMod, Whispers

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -102,6 +102,10 @@ type Client struct {
 	onEventChannelShieldModeEnd                             func(event EventChannelShieldModeEnd)
 	onEventChannelShoutoutCreate                            func(event EventChannelShoutoutCreate)
 	onEventChannelShoutoutReceive                           func(event EventChannelShoutoutReceive)
+	onEventAutomodMessageHold                               func(event EventAutomodMessageHold)
+	onEventAutomodMessageUpdate                             func(event EventAutomodMessageUpdate)
+	onEventAutomodSettingsUpdate                            func(event EventAutomodSettingsUpdate)
+	onEventAutomodTermsUpdate                               func(event EventAutomodTermsUpdate)
 }
 
 func NewClient() *Client {
@@ -369,6 +373,14 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelShoutoutCreate, *event)
 	case *EventChannelShoutoutReceive:
 		callFunc(c.onEventChannelShoutoutReceive, *event)
+	case *EventAutomodMessageHold:
+		callFunc(c.onEventAutomodMessageHold, *event)
+	case *EventAutomodMessageUpdate:
+		callFunc(c.onEventAutomodMessageUpdate, *event)
+	case *EventAutomodSettingsUpdate:
+		callFunc(c.onEventAutomodSettingsUpdate, *event)
+	case *EventAutomodTermsUpdate:
+		callFunc(c.onEventAutomodTermsUpdate, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -604,4 +616,20 @@ func (c *Client) OnEventChannelShoutoutCreate(callback func(event EventChannelSh
 
 func (c *Client) OnEventChannelShoutoutReceive(callback func(event EventChannelShoutoutReceive)) {
 	c.onEventChannelShoutoutReceive = callback
+}
+
+func (c *Client) OnEventAutomodMessageHold(callback func(event EventAutomodMessageHold)) {
+	c.onEventAutomodMessageHold = callback
+}
+
+func (c *Client) OnEventAutomodMessageUpdate(callback func(event EventAutomodMessageUpdate)) {
+	c.onEventAutomodMessageUpdate = callback
+}
+
+func (c *Client) OnEventAutomodSettingsUpdate(callback func(event EventAutomodSettingsUpdate)) {
+	c.onEventAutomodSettingsUpdate = callback
+}
+
+func (c *Client) OnEventAutomodTermsUpdate(callback func(event EventAutomodTermsUpdate)) {
+	c.onEventAutomodTermsUpdate = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -118,6 +118,7 @@ type Client struct {
 	onEventChannelSharedChatBegin                           func(event EventChannelSharedChatBegin)
 	onEventChannelSharedChatUpdate                          func(event EventChannelSharedChatUpdate)
 	onEventChannelSharedChatEnd                             func(event EventChannelSharedChatEnd)
+	onEventUserWhisperMessage                               func(event EventUserWhisperMessage)
 }
 
 func NewClient() *Client {
@@ -417,6 +418,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelSharedChatUpdate, *event)
 	case *EventChannelSharedChatEnd:
 		callFunc(c.onEventChannelSharedChatEnd, *event)
+	case *EventUserWhisperMessage:
+		callFunc(c.onEventUserWhisperMessage, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -716,4 +719,8 @@ func (c *Client) OnEventChannelSharedChatUpdate(callback func(event EventChannel
 
 func (c *Client) OnEventChannelSharedChatEnd(callback func(event EventChannelSharedChatEnd)) {
 	c.onEventChannelSharedChatEnd = callback
+}
+
+func (c *Client) OnEventUserWhisperMessage(callback func(event EventUserWhisperMessage)) {
+	c.onEventUserWhisperMessage = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -108,6 +108,12 @@ type Client struct {
 	onEventAutomodTermsUpdate                               func(event EventAutomodTermsUpdate)
 	onEventChannelChatUserMessageHold                       func(event EventChannelChatUserMessageHold)
 	onEventChannelChatUserMessageUpdate                     func(event EventChannelChatUserMessageUpdate)
+	onEventChannelChatClear                                 func(event EventChannelChatClear)
+	onEventChannelChatClearUserMessages                     func(event EventChannelChatClearUserMessages)
+	onEventChannelChatMessage                               func(event EventChannelChatMessage)
+	onEventChannelChatMessageDelete                         func(event EventChannelChatMessageDelete)
+	onEventChannelChatNotification                          func(event EventChannelChatNotification)
+	onEventChannelChatSettingsUpdate                        func(event EventChannelChatSettingsUpdate)
 }
 
 func NewClient() *Client {
@@ -387,6 +393,18 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelChatUserMessageHold, *event)
 	case *EventChannelChatUserMessageUpdate:
 		callFunc(c.onEventChannelChatUserMessageUpdate, *event)
+	case *EventChannelChatClear:
+		callFunc(c.onEventChannelChatClear, *event)
+	case *EventChannelChatClearUserMessages:
+		callFunc(c.onEventChannelChatClearUserMessages, *event)
+	case *EventChannelChatMessage:
+		callFunc(c.onEventChannelChatMessage, *event)
+	case *EventChannelChatMessageDelete:
+		callFunc(c.onEventChannelChatMessageDelete, *event)
+	case *EventChannelChatNotification:
+		callFunc(c.onEventChannelChatNotification, *event)
+	case *EventChannelChatSettingsUpdate:
+		callFunc(c.onEventChannelChatSettingsUpdate, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -646,4 +664,28 @@ func (c *Client) OnEventChannelChatUserMessageHold(callback func(event EventChan
 
 func (c *Client) OnEventChannelChatUserMessageUpdate(callback func(event EventChannelChatUserMessageUpdate)) {
 	c.onEventChannelChatUserMessageUpdate = callback
+}
+
+func (c *Client) OnEventChannelChatClear(callback func(event EventChannelChatClear)) {
+	c.onEventChannelChatClear = callback
+}
+
+func (c *Client) OnEventChannelChatClearUserMessages(callback func(event EventChannelChatClearUserMessages)) {
+	c.onEventChannelChatClearUserMessages = callback
+}
+
+func (c *Client) OnEventChannelChatMessage(callback func(event EventChannelChatMessage)) {
+	c.onEventChannelChatMessage = callback
+}
+
+func (c *Client) OnEventChannelChatMessageDelete(callback func(event EventChannelChatMessageDelete)) {
+	c.onEventChannelChatMessageDelete = callback
+}
+
+func (c *Client) OnEventChannelChatNotification(callback func(event EventChannelChatNotification)) {
+	c.onEventChannelChatNotification = callback
+}
+
+func (c *Client) OnEventChannelChatSettingsUpdate(callback func(event EventChannelChatSettingsUpdate)) {
+	c.onEventChannelChatSettingsUpdate = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -115,6 +115,7 @@ type Client struct {
 	onEventChannelChatNotification                          func(event EventChannelChatNotification)
 	onEventChannelChatSettingsUpdate                        func(event EventChannelChatSettingsUpdate)
 	onEventChannelSuspiciousUserMessage                     func(event EventChannelSuspiciousUserMessage)
+	onEventChannelSuspiciousUserUpdate                      func(event EventChannelSuspiciousUserUpdate)
 	onEventChannelSharedChatBegin                           func(event EventChannelSharedChatBegin)
 	onEventChannelSharedChatUpdate                          func(event EventChannelSharedChatUpdate)
 	onEventChannelSharedChatEnd                             func(event EventChannelSharedChatEnd)
@@ -412,6 +413,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelChatSettingsUpdate, *event)
 	case *EventChannelSuspiciousUserMessage:
 		callFunc(c.onEventChannelSuspiciousUserMessage, *event)
+	case *EventChannelSuspiciousUserUpdate:
+		callFunc(c.onEventChannelSuspiciousUserUpdate, *event)
 	case *EventChannelSharedChatBegin:
 		callFunc(c.onEventChannelSharedChatBegin, *event)
 	case *EventChannelSharedChatUpdate:
@@ -707,6 +710,10 @@ func (c *Client) OnEventChannelChatSettingsUpdate(callback func(event EventChann
 
 func (c *Client) OnEventChannelSuspiciousUserMessage(callback func(event EventChannelSuspiciousUserMessage)) {
 	c.onEventChannelSuspiciousUserMessage = callback
+}
+
+func (c *Client) OnEventChannelSuspiciousUserUpdate(callback func(event EventChannelSuspiciousUserUpdate)) {
+	c.onEventChannelSuspiciousUserUpdate = callback
 }
 
 func (c *Client) OnEventChannelSharedChatBegin(callback func(event EventChannelSharedChatBegin)) {

--- a/conn.go
+++ b/conn.go
@@ -115,6 +115,9 @@ type Client struct {
 	onEventChannelChatNotification                          func(event EventChannelChatNotification)
 	onEventChannelChatSettingsUpdate                        func(event EventChannelChatSettingsUpdate)
 	onEventChannelSuspiciousUserMessage                     func(event EventChannelSuspiciousUserMessage)
+	onEventChannelSharedChatBegin                           func(event EventChannelSharedChatBegin)
+	onEventChannelSharedChatUpdate                          func(event EventChannelSharedChatUpdate)
+	onEventChannelSharedChatEnd                             func(event EventChannelSharedChatEnd)
 }
 
 func NewClient() *Client {
@@ -408,6 +411,12 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelChatSettingsUpdate, *event)
 	case *EventChannelSuspiciousUserMessage:
 		callFunc(c.onEventChannelSuspiciousUserMessage, *event)
+	case *EventChannelSharedChatBegin:
+		callFunc(c.onEventChannelSharedChatBegin, *event)
+	case *EventChannelSharedChatUpdate:
+		callFunc(c.onEventChannelSharedChatUpdate, *event)
+	case *EventChannelSharedChatEnd:
+		callFunc(c.onEventChannelSharedChatEnd, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -695,4 +704,16 @@ func (c *Client) OnEventChannelChatSettingsUpdate(callback func(event EventChann
 
 func (c *Client) OnEventChannelSuspiciousUserMessage(callback func(event EventChannelSuspiciousUserMessage)) {
 	c.onEventChannelSuspiciousUserMessage = callback
+}
+
+func (c *Client) OnEventChannelSharedChatBegin(callback func(event EventChannelSharedChatBegin)) {
+	c.onEventChannelSharedChatBegin = callback
+}
+
+func (c *Client) OnEventChannelSharedChatUpdate(callback func(event EventChannelSharedChatUpdate)) {
+	c.onEventChannelSharedChatUpdate = callback
+}
+
+func (c *Client) OnEventChannelSharedChatEnd(callback func(event EventChannelSharedChatEnd)) {
+	c.onEventChannelSharedChatEnd = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -106,6 +106,8 @@ type Client struct {
 	onEventAutomodMessageUpdate                             func(event EventAutomodMessageUpdate)
 	onEventAutomodSettingsUpdate                            func(event EventAutomodSettingsUpdate)
 	onEventAutomodTermsUpdate                               func(event EventAutomodTermsUpdate)
+	onEventChannelChatUserMessageHold                       func(event EventChannelChatUserMessageHold)
+	onEventChannelChatUserMessageUpdate                     func(event EventChannelChatUserMessageUpdate)
 }
 
 func NewClient() *Client {
@@ -381,6 +383,10 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventAutomodSettingsUpdate, *event)
 	case *EventAutomodTermsUpdate:
 		callFunc(c.onEventAutomodTermsUpdate, *event)
+	case *EventChannelChatUserMessageHold:
+		callFunc(c.onEventChannelChatUserMessageHold, *event)
+	case *EventChannelChatUserMessageUpdate:
+		callFunc(c.onEventChannelChatUserMessageUpdate, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -632,4 +638,12 @@ func (c *Client) OnEventAutomodSettingsUpdate(callback func(event EventAutomodSe
 
 func (c *Client) OnEventAutomodTermsUpdate(callback func(event EventAutomodTermsUpdate)) {
 	c.onEventAutomodTermsUpdate = callback
+}
+
+func (c *Client) OnEventChannelChatUserMessageHold(callback func(event EventChannelChatUserMessageHold)) {
+	c.onEventChannelChatUserMessageHold = callback
+}
+
+func (c *Client) OnEventChannelChatUserMessageUpdate(callback func(event EventChannelChatUserMessageUpdate)) {
+	c.onEventChannelChatUserMessageUpdate = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -114,6 +114,7 @@ type Client struct {
 	onEventChannelChatMessageDelete                         func(event EventChannelChatMessageDelete)
 	onEventChannelChatNotification                          func(event EventChannelChatNotification)
 	onEventChannelChatSettingsUpdate                        func(event EventChannelChatSettingsUpdate)
+	onEventChannelSuspiciousUserMessage                     func(event EventChannelSuspiciousUserMessage)
 }
 
 func NewClient() *Client {
@@ -405,6 +406,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelChatNotification, *event)
 	case *EventChannelChatSettingsUpdate:
 		callFunc(c.onEventChannelChatSettingsUpdate, *event)
+	case *EventChannelSuspiciousUserMessage:
+		callFunc(c.onEventChannelSuspiciousUserMessage, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -688,4 +691,8 @@ func (c *Client) OnEventChannelChatNotification(callback func(event EventChannel
 
 func (c *Client) OnEventChannelChatSettingsUpdate(callback func(event EventChannelChatSettingsUpdate)) {
 	c.onEventChannelChatSettingsUpdate = callback
+}
+
+func (c *Client) OnEventChannelSuspiciousUserMessage(callback func(event EventChannelSuspiciousUserMessage)) {
+	c.onEventChannelSuspiciousUserMessage = callback
 }

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -693,3 +693,13 @@ func TestEventChannelSharedChatEnd(t *testing.T) {
 		})
 	}, twitch.SubChannelSharedChatEnd)
 }
+
+func TestEventUserWhisperMessage(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventUserWhisperMessage(func(event twitch.EventUserWhisperMessage) {
+			close(ch)
+		})
+	}, twitch.SubUserWhisperMessage)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -593,3 +593,63 @@ func TestEventChannelChatUserMessageUpdate(t *testing.T) {
 		})
 	}, twitch.SubChannelChatUserMessageUpdate)
 }
+
+func TestEventChannelChatClear(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatClear(func(event twitch.EventChannelChatClear) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatClear)
+}
+
+func TestEventChannelChatClearUserMessages(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatClearUserMessages(func(event twitch.EventChannelChatClearUserMessages) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatClearUserMessages)
+}
+
+func TestEventChannelChatMessage(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatMessage(func(event twitch.EventChannelChatMessage) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatMessage)
+}
+
+func TestEventChannelChatMessageDelete(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatMessageDelete(func(event twitch.EventChannelChatMessageDelete) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatMessageDelete)
+}
+
+func TestEventChannelChatNotification(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatNotification(func(event twitch.EventChannelChatNotification) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatNotification)
+}
+
+func TestEventChannelChatSettingsUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatSettingsUpdate(func(event twitch.EventChannelChatSettingsUpdate) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatSettingsUpdate)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -533,3 +533,43 @@ func TestEventChannelShoutoutReceive(t *testing.T) {
 		})
 	}, twitch.SubChannelShoutoutReceive)
 }
+
+func TestEventAutomodMessageHold(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventAutomodMessageHold(func(event twitch.EventAutomodMessageHold) {
+			close(ch)
+		})
+	}, twitch.SubAutomodMessageHold)
+}
+
+func TestEventAutomodMessageUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventAutomodMessageUpdate(func(event twitch.EventAutomodMessageUpdate) {
+			close(ch)
+		})
+	}, twitch.SubAutomodMessageUpdate)
+}
+
+func TestEventAutomodSettingsUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventAutomodSettingsUpdate(func(event twitch.EventAutomodSettingsUpdate) {
+			close(ch)
+		})
+	}, twitch.SubAutomodSettingsUpdate)
+}
+
+func TestEventAutomodTermsUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventAutomodTermsUpdate(func(event twitch.EventAutomodTermsUpdate) {
+			close(ch)
+		})
+	}, twitch.SubAutomodTermsUpdate)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -653,3 +653,13 @@ func TestEventChannelChatSettingsUpdate(t *testing.T) {
 		})
 	}, twitch.SubChannelChatSettingsUpdate)
 }
+
+func TestEventChannelSuspiciousUserMessage(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelSuspiciousUserMessage(func(event twitch.EventChannelSuspiciousUserMessage) {
+			close(ch)
+		})
+	}, twitch.SubChannelSuspiciousUserMessage)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -664,6 +664,16 @@ func TestEventChannelSuspiciousUserMessage(t *testing.T) {
 	}, twitch.SubChannelSuspiciousUserMessage)
 }
 
+func TestEventChannelSuspiciousUserUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelSuspiciousUserUpdate(func(event twitch.EventChannelSuspiciousUserUpdate) {
+			close(ch)
+		})
+	}, twitch.SubChannelSuspiciousUserUpdate)
+}
+
 func TestEventChannelSharedChatBegin(t *testing.T) {
 	t.Parallel()
 

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -573,3 +573,23 @@ func TestEventAutomodTermsUpdate(t *testing.T) {
 		})
 	}, twitch.SubAutomodTermsUpdate)
 }
+
+func TestEventChannelChatUserMessageHold(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatUserMessageHold(func(event twitch.EventChannelChatUserMessageHold) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatUserMessageHold)
+}
+
+func TestEventChannelChatUserMessageUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChatUserMessageUpdate(func(event twitch.EventChannelChatUserMessageUpdate) {
+			close(ch)
+		})
+	}, twitch.SubChannelChatUserMessageUpdate)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -663,3 +663,33 @@ func TestEventChannelSuspiciousUserMessage(t *testing.T) {
 		})
 	}, twitch.SubChannelSuspiciousUserMessage)
 }
+
+func TestEventChannelSharedChatBegin(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelSharedChatBegin(func(event twitch.EventChannelSharedChatBegin) {
+			close(ch)
+		})
+	}, twitch.SubChannelSharedChatBegin)
+}
+
+func TestEventChannelSharedChatUpdate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelSharedChatUpdate(func(event twitch.EventChannelSharedChatUpdate) {
+			close(ch)
+		})
+	}, twitch.SubChannelSharedChatUpdate)
+}
+
+func TestEventChannelSharedChatEnd(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelSharedChatEnd(func(event twitch.EventChannelSharedChatEnd) {
+			close(ch)
+		})
+	}, twitch.SubChannelSharedChatEnd)
+}

--- a/events.go
+++ b/events.go
@@ -801,3 +801,18 @@ type EventChannelSharedChatEnd struct {
 
 	SessionId string `json:"session_id"`
 }
+
+type UserWhisper struct {
+	Text string `json:"text"`
+}
+
+type EventUserWhisperMessage struct {
+	FromUserId    string      `json:"from_user_id"`
+	FromUserLogin string      `json:"from_user_login"`
+	FromUserName  string      `json:"from_user_name"`
+	ToUserId      string      `json:"to_user_id"`
+	ToUserLogin   string      `json:"to_user_login"`
+	ToUserName    string      `json:"to_user_name"`
+	WhisperId     string      `json:"whisper_id"`
+	Whisper       UserWhisper `json:"whisper"`
+}

--- a/events.go
+++ b/events.go
@@ -761,3 +761,20 @@ type EventChannelChatSettingsUpdate struct {
 	SubscriberMode              bool `json:"subscriber_mode"`
 	UniqueChatMode              bool `json:"unique_chat_mode"`
 }
+
+type SuspiciousUserChatMessage struct {
+	ChatMessage
+
+	MessageId string `json:"message_id"`
+}
+
+type EventChannelSuspiciousUserMessage struct {
+	Broadcaster
+	User
+
+	LowTrustStatus       string                    `json:"low_trust_status"`
+	SharedBanChannelIds  []string                  `json:"shared_ban_channel_ids"`
+	Types                []string                  `json:"types"`
+	BanEvasionEvaluation string                    `json:"ban_evasion_evaluation"`
+	Message              SuspiciousUserChatMessage `json:"message"`
+}

--- a/events.go
+++ b/events.go
@@ -509,7 +509,7 @@ type EventAutomodMessageUpdate struct {
 	Fragments AutomodMessageFragments `json:"fragments"`
 }
 
-type AutomodSettingsDatum struct {
+type EventAutomodSettingsUpdate struct {
 	Broadcaster
 	Moderator
 
@@ -522,10 +522,6 @@ type AutomodSettingsDatum struct {
 	Swearing                int  `json:"swearing"`
 	RaceEthnicityOrReligion int  `json:"race_ethnicity_or_religion"`
 	SexBasedTerms           int  `json:"sex_based_terms"`
-}
-
-type EventAutomodSettingsUpdate struct {
-	Data []AutomodSettingsDatum `json:"data"`
 }
 
 type EventAutomodTermsUpdate struct {

--- a/events.go
+++ b/events.go
@@ -23,6 +23,24 @@ type Moderator struct {
 	ModeratorUserName  string `json:"moderator_user_name"`
 }
 
+type Target struct {
+	TargetUserId    string `json:"target_user_id"`
+	TargetUserLogin string `json:"target_user_login"`
+	TargetUserName  string `json:"target_user_name"`
+}
+
+type SourceBroadcaster struct {
+	SourceBroadcasterUserId    string `json:"source_broadcaster_user_id"`
+	SourceBroadcasterUserLogin string `json:"source_broadcaster_user_login"`
+	SourceBroadcasterUserName  string `json:"source_broadcaster_user_name"`
+}
+
+type Chatter struct {
+	ChatterUserId    string `json:"chatter_user_id"`
+	ChatterUserLogin string `json:"chatter_user_login"`
+	ChatterUserName  string `json:"chatter_user_name"`
+}
+
 type EventChannelUpdate struct {
 	Broadcaster
 
@@ -556,4 +574,190 @@ type EventChannelChatUserMessageUpdate struct {
 	Status    string      `json:"status"`
 	MessageId string      `json:"message_id"`
 	Message   ChatMessage `json:"message"`
+}
+
+type EventChannelChatClear Broadcaster
+
+type EventChannelChatClearUserMessages struct {
+	Broadcaster
+	Target
+}
+
+type ChatMessageUserBadge struct {
+	SetId string `json:"set_id"`
+	Id    string `json:"id"`
+	Info  string `json:"info"`
+}
+
+type ChatMessageCheer struct {
+	Bits int `json:"bits"`
+}
+
+type ChatMessageReply struct {
+	ParentMessageId   string `json:"parent_message_id"`
+	ParentMessageBody string `json:"parent_message_body"`
+	ParentUserId      string `json:"parent_user_id"`
+	ParentUserName    string `json:"parent_user_name"`
+	ParentUserLogin   string `json:"parent_user_login"`
+	ThreadMessageId   string `json:"thread_message_id"`
+	ThreadUserId      string `json:"thread_user_id"`
+	ThreadUserName    string `json:"thread_user_name"`
+	ThreadUserLogin   string `json:"thread_user_login"`
+}
+
+type EventChannelChatMessage struct {
+	Broadcaster
+	SourceBroadcaster
+	Chatter
+
+	MessageId                   string                  `json:"message_id"`
+	SourceMessageId             string                  `json:"source_message_id"`
+	Message                     ChatMessage             `json:"message"`
+	Color                       string                  `json:"color"`
+	Badges                      []ChatMessageUserBadge  `json:"badges"`
+	SourceBadges                *[]ChatMessageUserBadge `json:"source_badges,omitempty"`
+	MessageType                 string                  `json:"message_type"`
+	Cheer                       *ChatMessageCheer       `json:"cheer,omitempty"`
+	Reply                       *ChatMessageReply       `json:"reply,omitempty"`
+	ChannelPointsCustomRewardId string                  `json:"channel_points_custom_reward_id"`
+	ChannelPointsAnimationId    string                  `json:"channel_points_animation_id"`
+}
+
+type EventChannelChatMessageDelete struct {
+	Broadcaster
+	Target
+
+	MessageId string `json:"message_id"`
+}
+
+type ChatNotificationSub struct {
+	SubTier        string `json:"sub_tier"`
+	IsPrime        bool   `json:"is_prime"`
+	DurationMonths int    `json:"duration_months"`
+}
+
+type ChatNotificationResub struct {
+	CumulativeMonths  int    `json:"cumulative_months"`
+	DurationMonths    int    `json:"duration_months"`
+	StreakMonths      int    `json:"streak_months"`
+	SubTier           string `json:"sub_tier"`
+	IsPrime           bool   `json:"is_prime"`
+	IsGift            bool   `json:"is_gift"`
+	GifterIsAnonymous bool   `json:"gifter_is_anonymous"`
+	GifterUserId      string `json:"gifter_user_id"`
+	GifterUserName    string `json:"gifter_user_name"`
+	GifterUserLogin   string `json:"gifter_user_login"`
+}
+
+type ChatNotificationSubGift struct {
+	DurationMonths     int    `json:"duration_months"`
+	CumulativeTotal    int    `json:"cumulative_total"`
+	RecipientUserId    string `json:"recipient_user_id"`
+	RecipientUserName  string `json:"recipient_user_name"`
+	RecipientUserLogin string `json:"recipient_user_login"`
+	SubTier            string `json:"sub_tier"`
+	CommunityGiftId    string `json:"community_gift_id"`
+}
+
+type ChatNotificationCommunitySubGift struct {
+	Id              string `json:"id"`
+	Total           int    `json:"total"`
+	SubTier         string `json:"sub_tier"`
+	CumulativeTotal int    `json:"cumulative_total"`
+}
+
+type ChatNotificationGiftPaidUpgrade struct {
+	GifterIsAnonymous bool   `json:"gifter_is_anonymous"`
+	GifterUserId      string `json:"gifter_user_id"`
+	GifterUserName    string `json:"gifter_user_name"`
+}
+
+type ChatNotificationPrimePaidUpgrade struct {
+	SubTier string `json:"sub_tier"`
+}
+
+type ChatNotificationPayItForward struct {
+	GifterIsAnonymous bool   `json:"gifter_is_anonymous"`
+	GifterUserId      string `json:"gifter_user_id"`
+	GifterUserName    string `json:"gifter_user_name"`
+	GifterUserLogin   string `json:"gifter_user_login"`
+}
+
+type ChatNotificationRaid struct {
+	User
+
+	ViewerCount     string `json:"viewer_count"`
+	ProfileImageUrl string `json:"profile_image_url"`
+}
+
+type ChatNotificationUnraid struct{}
+
+type ChatNotificationAnnouncement struct {
+	Color string `json:"color"`
+}
+
+type ChatNotificationBitsBadgeTier struct {
+	Tier int `json:"tier"`
+}
+
+type ChatNotificationCharityDonationAmount struct {
+	Value        int    `json:"value"`
+	DecimalPlace int    `json:"decimal_place"`
+	Currency     string `json:"currency"`
+}
+
+type ChatNotificationCharityDonation struct {
+	CharityName string                                `json:"charity_name"`
+	Amount      ChatNotificationCharityDonationAmount `json:"amount"`
+}
+
+type EventChannelChatNotification struct {
+	Broadcaster
+	SourceBroadcaster
+	Chatter
+
+	ChatterIsAnonymous bool                    `json:"chatter_is_anonymous"`
+	Color              string                  `json:"color"`
+	Badges             []ChatMessageUserBadge  `json:"badges"`
+	SourceBadges       *[]ChatMessageUserBadge `json:"source_badges"`
+	SystemMessage      string                  `json:"system_message"`
+	MessageId          string                  `json:"message_id"`
+	SourceMessageId    string                  `json:"source_message_id"`
+	Message            ChatMessage             `json:"message"`
+
+	NoticeType       string                            `json:"notice_type"`
+	Sub              *ChatNotificationSub              `json:"sub,omitempty"`
+	Resub            *ChatNotificationResub            `json:"resub,omitempty"`
+	SubGift          *ChatNotificationSubGift          `json:"sub_gift,omitempty"`
+	CommunitySubGift *ChatNotificationCommunitySubGift `json:"community_sub_gift,omitempty"`
+	GiftPaidUpgrade  *ChatNotificationGiftPaidUpgrade  `json:"gift_paid_upgrade,omitempty"`
+	PrimePaidUpgrade *ChatNotificationPrimePaidUpgrade `json:"prime_paid_upgrade,omitempty"`
+	PayItForward     *ChatNotificationPayItForward     `json:"pay_it_forward,omitempty"`
+	Raid             *ChatNotificationRaid             `json:"raid,omitempty"`
+	Unraid           *ChatNotificationUnraid           `json:"unraid,omitempty"`
+	Announcement     *ChatNotificationAnnouncement     `json:"announcement,omitempty"`
+	BitsBadgeTier    *ChatNotificationBitsBadgeTier    `json:"bits_badge_tier,omitempty"`
+	CharityDonation  *ChatNotificationCharityDonation  `json:"charity_donation,omitempty"`
+
+	SharedChatSub              *ChatNotificationSub              `json:"shared_chat_sub"`
+	SharedChatResub            *ChatNotificationResub            `json:"shared_chat_resub"`
+	SharedChatSubGift          *ChatNotificationSubGift          `json:"shared_chat_sub_gift"`
+	SharedChatCommunitySubGift *ChatNotificationCommunitySubGift `json:"shared_chat_community_sub_gift"`
+	SharedChatGiftPaidUpgrade  *ChatNotificationGiftPaidUpgrade  `json:"shared_chat_gift_paid_upgrade"`
+	SharedChatPrimePaidUpgrade *ChatNotificationPrimePaidUpgrade `json:"shared_chat_prime_paid_upgrade"`
+	SharedChatPayItForward     *ChatNotificationPayItForward     `json:"shared_chat_pay_it_forward"`
+	SharedChatRaid             *ChatNotificationRaid             `json:"shared_chat_raid"`
+	SharedChatAnnouncement     *ChatNotificationAnnouncement     `json:"shared_chat_announcement"`
+}
+
+type EventChannelChatSettingsUpdate struct {
+	Broadcaster
+
+	EmoteMode                   bool `json:"emote_mode"`
+	FollowerMode                bool `json:"follower_mode"`
+	FollowerModeDurationMinutes int  `json:"follower_mode_duration_minutes"`
+	SlowMode                    bool `json:"slow_mode"`
+	SlowModeWaitTimeSeconds     int  `json:"slow_mode_wait_time_seconds"`
+	SubscriberMode              bool `json:"subscriber_mode"`
+	UniqueChatMode              bool `json:"unique_chat_mode"`
 }

--- a/events.go
+++ b/events.go
@@ -745,15 +745,15 @@ type EventChannelChatNotification struct {
 	BitsBadgeTier    *ChatNotificationBitsBadgeTier    `json:"bits_badge_tier,omitempty"`
 	CharityDonation  *ChatNotificationCharityDonation  `json:"charity_donation,omitempty"`
 
-	SharedChatSub              *ChatNotificationSub              `json:"shared_chat_sub"`
-	SharedChatResub            *ChatNotificationResub            `json:"shared_chat_resub"`
-	SharedChatSubGift          *ChatNotificationSubGift          `json:"shared_chat_sub_gift"`
-	SharedChatCommunitySubGift *ChatNotificationCommunitySubGift `json:"shared_chat_community_sub_gift"`
-	SharedChatGiftPaidUpgrade  *ChatNotificationGiftPaidUpgrade  `json:"shared_chat_gift_paid_upgrade"`
-	SharedChatPrimePaidUpgrade *ChatNotificationPrimePaidUpgrade `json:"shared_chat_prime_paid_upgrade"`
-	SharedChatPayItForward     *ChatNotificationPayItForward     `json:"shared_chat_pay_it_forward"`
-	SharedChatRaid             *ChatNotificationRaid             `json:"shared_chat_raid"`
-	SharedChatAnnouncement     *ChatNotificationAnnouncement     `json:"shared_chat_announcement"`
+	SharedChatSub              *ChatNotificationSub              `json:"shared_chat_sub,omitempty"`
+	SharedChatResub            *ChatNotificationResub            `json:"shared_chat_resub,omitempty"`
+	SharedChatSubGift          *ChatNotificationSubGift          `json:"shared_chat_sub_gift,omitempty"`
+	SharedChatCommunitySubGift *ChatNotificationCommunitySubGift `json:"shared_chat_community_sub_gift,omitempty"`
+	SharedChatGiftPaidUpgrade  *ChatNotificationGiftPaidUpgrade  `json:"shared_chat_gift_paid_upgrade,omitempty"`
+	SharedChatPrimePaidUpgrade *ChatNotificationPrimePaidUpgrade `json:"shared_chat_prime_paid_upgrade,omitempty"`
+	SharedChatPayItForward     *ChatNotificationPayItForward     `json:"shared_chat_pay_it_forward,omitempty"`
+	SharedChatRaid             *ChatNotificationRaid             `json:"shared_chat_raid,omitempty"`
+	SharedChatAnnouncement     *ChatNotificationAnnouncement     `json:"shared_chat_announcement,omitempty"`
 }
 
 type EventChannelChatSettingsUpdate struct {

--- a/events.go
+++ b/events.go
@@ -540,3 +540,20 @@ type EventAutomodTermsUpdate struct {
 	FromAutomod bool     `json:"from_automod"`
 	Terms       []string `json:"terms"`
 }
+
+type EventChannelChatUserMessageHold struct {
+	Broadcaster
+	User
+
+	MessageId string      `json:"message_id"`
+	Message   ChatMessage `json:"message"`
+}
+
+type EventChannelChatUserMessageUpdate struct {
+	Broadcaster
+	User
+
+	Status    string      `json:"status"`
+	MessageId string      `json:"message_id"`
+	Message   ChatMessage `json:"message"`
+}

--- a/events.go
+++ b/events.go
@@ -464,3 +464,75 @@ type EventChannelShoutoutReceive struct {
 	ViewerCount              int       `json:"viewer_count"`
 	StartedAt                time.Time `json:"started_at"`
 }
+
+type AutomodMessageEmoteFragment struct {
+	Text  string `json:"text"`
+	Id    string `json:"id"`
+	SetId string `json:"set-id"`
+}
+
+type AutomodMessageCheermoteFragment struct {
+	Text   string `json:"text"`
+	Amount int    `json:"amount"`
+	Prefix string `json:"prefix"`
+	Tier   int    `json:"tier"`
+}
+
+type AutomodMessageFragments struct {
+	Emotes     []AutomodMessageEmoteFragment     `json:"emotes"`
+	Cheermotes []AutomodMessageCheermoteFragment `json:"cheermotes"`
+}
+
+type EventAutomodMessageHold struct {
+	Broadcaster
+	User
+
+	MessageId string                  `json:"message_id"`
+	Message   string                  `json:"message"`
+	Level     int                     `json:"level"`
+	Category  string                  `json:"category"`
+	HeldAt    time.Time               `json:"held_at"`
+	Fragments AutomodMessageFragments `json:"fragments"`
+}
+
+type EventAutomodMessageUpdate struct {
+	Broadcaster
+	User
+	Moderator
+
+	MessageId string                  `json:"message_id"`
+	Message   string                  `json:"message"`
+	Level     int                     `json:"level"`
+	Category  string                  `json:"category"`
+	Status    string                  `json:"status"`
+	HeldAt    time.Time               `json:"held_at"`
+	Fragments AutomodMessageFragments `json:"fragments"`
+}
+
+type AutomodSettingsDatum struct {
+	Broadcaster
+	Moderator
+
+	OverallLevel            *int `json:"overall_level"`
+	Disability              int  `json:"disability"`
+	Aggression              int  `json:"aggression"`
+	SexualitySexOrGender    int  `json:"sexuality_sex_or_gender"`
+	Misogyny                int  `json:"misogyny"`
+	Bullying                int  `json:"bullying"`
+	Swearing                int  `json:"swearing"`
+	RaceEthnicityOrReligion int  `json:"race_ethnicity_or_religion"`
+	SexBasedTerms           int  `json:"sex_based_terms"`
+}
+
+type EventAutomodSettingsUpdate struct {
+	Data []AutomodSettingsDatum `json:"data"`
+}
+
+type EventAutomodTermsUpdate struct {
+	Broadcaster
+	Moderator
+
+	Action      string   `json:"action"`
+	FromAutomod bool     `json:"from_automod"`
+	Terms       []string `json:"terms"`
+}

--- a/events.go
+++ b/events.go
@@ -785,6 +785,14 @@ type EventChannelSuspiciousUserMessage struct {
 	Message              SuspiciousUserChatMessage `json:"message"`
 }
 
+type EventChannelSuspiciousUserUpdate struct {
+	Broadcaster
+	Moderator
+	User
+
+	LowTrustStatus string `json:"low_trust_status"`
+}
+
 type EventChannelSharedChatBegin struct {
 	Broadcaster
 	HostBroadcaster

--- a/events.go
+++ b/events.go
@@ -465,34 +465,43 @@ type EventChannelShoutoutReceive struct {
 	StartedAt                time.Time `json:"started_at"`
 }
 
-type AutomodMessageEmoteFragment struct {
-	Text  string `json:"text"`
-	Id    string `json:"id"`
-	SetId string `json:"set-id"`
-}
-
-type AutomodMessageCheermoteFragment struct {
-	Text   string `json:"text"`
-	Amount int    `json:"amount"`
+type ChatMessageFragmentCheermote struct {
 	Prefix string `json:"prefix"`
+	Bits   int    `json:"bits"`
 	Tier   int    `json:"tier"`
 }
 
-type AutomodMessageFragments struct {
-	Emotes     []AutomodMessageEmoteFragment     `json:"emotes"`
-	Cheermotes []AutomodMessageCheermoteFragment `json:"cheermotes"`
+type ChatMessageFragmentEmote struct {
+	Id         string   `json:"id"`
+	EmoteSetId string   `json:"emote_set_id"`
+	OwnerId    string   `json:"owner_id"`
+	Format     []string `json:"format"`
+}
+
+type ChatMessageFragmentMention User
+
+type ChatMessageFragment struct {
+	Type      string                        `json:"type"`
+	Text      string                        `json:"text"`
+	Cheermote *ChatMessageFragmentCheermote `json:"cheermote,omitempty"`
+	Emote     *ChatMessageFragmentEmote     `json:"emote,omitempty"`
+	Mention   *ChatMessageFragmentMention   `json:"mention,omitempty"`
+}
+
+type ChatMessage struct {
+	Text      string                `json:"text"`
+	Fragments []ChatMessageFragment `json:"fragments"`
 }
 
 type EventAutomodMessageHold struct {
 	Broadcaster
 	User
 
-	MessageId string                  `json:"message_id"`
-	Message   string                  `json:"message"`
-	Level     int                     `json:"level"`
-	Category  string                  `json:"category"`
-	HeldAt    time.Time               `json:"held_at"`
-	Fragments AutomodMessageFragments `json:"fragments"`
+	MessageId string      `json:"message_id"`
+	Message   ChatMessage `json:"message"`
+	Level     int         `json:"level"`
+	Category  string      `json:"category"`
+	HeldAt    time.Time   `json:"held_at"`
 }
 
 type EventAutomodMessageUpdate struct {
@@ -500,13 +509,12 @@ type EventAutomodMessageUpdate struct {
 	User
 	Moderator
 
-	MessageId string                  `json:"message_id"`
-	Message   string                  `json:"message"`
-	Level     int                     `json:"level"`
-	Category  string                  `json:"category"`
-	Status    string                  `json:"status"`
-	HeldAt    time.Time               `json:"held_at"`
-	Fragments AutomodMessageFragments `json:"fragments"`
+	MessageId string      `json:"message_id"`
+	Message   ChatMessage `json:"message"`
+	Level     int         `json:"level"`
+	Category  string      `json:"category"`
+	Status    string      `json:"status"`
+	HeldAt    time.Time   `json:"held_at"`
 }
 
 type EventAutomodSettingsUpdate struct {

--- a/events.go
+++ b/events.go
@@ -41,6 +41,12 @@ type Chatter struct {
 	ChatterUserName  string `json:"chatter_user_name"`
 }
 
+type HostBroadcaster struct {
+	HostBroadcasterUserId    string `json:"host_broadcaster_user_id"`
+	HostBroadcasterUserLogin string `json:"host_broadcaster_user_login"`
+	HostBroadcasterUserName  string `json:"host_broadcaster_user_name"`
+}
+
 type EventChannelUpdate struct {
 	Broadcaster
 
@@ -777,4 +783,21 @@ type EventChannelSuspiciousUserMessage struct {
 	Types                []string                  `json:"types"`
 	BanEvasionEvaluation string                    `json:"ban_evasion_evaluation"`
 	Message              SuspiciousUserChatMessage `json:"message"`
+}
+
+type EventChannelSharedChatBegin struct {
+	Broadcaster
+	HostBroadcaster
+
+	SessionId    string        `json:"session_id"`
+	Participants []Broadcaster `json:"participants"`
+}
+
+type EventChannelSharedChatUpdate EventChannelSharedChatBegin
+
+type EventChannelSharedChatEnd struct {
+	Broadcaster
+	HostBroadcaster
+
+	SessionId string `json:"session_id"`
 }

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -74,6 +74,11 @@ var (
 	SubChannelShoutoutCreate  EventSubscription = "channel.shoutout.create"
 	SubChannelShoutoutReceive EventSubscription = "channel.shoutout.receive"
 
+	SubAutomodMessageHold    EventSubscription = "automod.message.hold"
+	SubAutomodMessageUpdate  EventSubscription = "automod.message.update"
+	SubAutomodSettingsUpdate EventSubscription = "automod.settings.update"
+	SubAutomodTermsUpdate    EventSubscription = "automod.terms.update"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -254,6 +259,22 @@ var (
 		SubChannelShoutoutReceive: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelShoutoutReceive](),
+		},
+		SubAutomodMessageHold: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventAutomodMessageHold](),
+		},
+		SubAutomodMessageUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventAutomodMessageUpdate](),
+		},
+		SubAutomodSettingsUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventAutomodSettingsUpdate](),
+		},
+		SubAutomodTermsUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventAutomodTermsUpdate](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -74,10 +74,12 @@ var (
 	SubChannelShoutoutCreate  EventSubscription = "channel.shoutout.create"
 	SubChannelShoutoutReceive EventSubscription = "channel.shoutout.receive"
 
-	SubAutomodMessageHold    EventSubscription = "automod.message.hold"
-	SubAutomodMessageUpdate  EventSubscription = "automod.message.update"
-	SubAutomodSettingsUpdate EventSubscription = "automod.settings.update"
-	SubAutomodTermsUpdate    EventSubscription = "automod.terms.update"
+	SubAutomodMessageHold           EventSubscription = "automod.message.hold"
+	SubAutomodMessageUpdate         EventSubscription = "automod.message.update"
+	SubAutomodSettingsUpdate        EventSubscription = "automod.settings.update"
+	SubAutomodTermsUpdate           EventSubscription = "automod.terms.update"
+	SubChannelChatUserMessageHold   EventSubscription = "channel.chat.user_message_hold"
+	SubChannelChatUserMessageUpdate EventSubscription = "channel.chat.user_message_update"
 
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
@@ -275,6 +277,14 @@ var (
 		SubAutomodTermsUpdate: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventAutomodTermsUpdate](),
+		},
+		SubChannelChatUserMessageHold: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatUserMessageHold](),
+		},
+		SubChannelChatUserMessageUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatUserMessageUpdate](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -93,6 +93,8 @@ var (
 	SubChannelSharedChatUpdate EventSubscription = "channel.shared_chat.update"
 	SubChannelSharedChatEnd    EventSubscription = "channel.shared_chat.end"
 
+	SubUserWhisperMessage EventSubscription = "user.whisper.message"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -337,6 +339,10 @@ var (
 		SubChannelSharedChatEnd: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelSharedChatEnd](),
+		},
+		SubUserWhisperMessage: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventUserWhisperMessage](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -88,6 +88,7 @@ var (
 	SubChannelChatNotification      EventSubscription = "channel.chat.notification"
 	SubChannelChatSettingsUpdate    EventSubscription = "channel.chat_settings.update"
 	SubChannelSuspiciousUserMessage EventSubscription = "channel.suspicious_user.message"
+	SubChannelSuspiciousUserUpdate  EventSubscription = "channel.suspicious_user.update"
 
 	SubChannelSharedChatBegin  EventSubscription = "channel.shared_chat.begin"
 	SubChannelSharedChatUpdate EventSubscription = "channel.shared_chat.update"
@@ -327,6 +328,10 @@ var (
 		SubChannelSuspiciousUserMessage: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelSuspiciousUserMessage](),
+		},
+		SubChannelSuspiciousUserUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelSuspiciousUserUpdate](),
 		},
 		SubChannelSharedChatBegin: {
 			Version:  "1",

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -81,6 +81,13 @@ var (
 	SubChannelChatUserMessageHold   EventSubscription = "channel.chat.user_message_hold"
 	SubChannelChatUserMessageUpdate EventSubscription = "channel.chat.user_message_update"
 
+	SubChannelChatClear             EventSubscription = "channel.chat.clear"
+	SubChannelChatClearUserMessages EventSubscription = "channel.chat.clear_user_messages"
+	SubChannelChatMessage           EventSubscription = "channel.chat.message"
+	SubChannelChatMessageDelete     EventSubscription = "channel.chat.message_delete"
+	SubChannelChatNotification      EventSubscription = "channel.chat.notification"
+	SubChannelChatSettingsUpdate    EventSubscription = "channel.chat_settings.update"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -285,6 +292,30 @@ var (
 		SubChannelChatUserMessageUpdate: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelChatUserMessageUpdate](),
+		},
+		SubChannelChatClear: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatClear](),
+		},
+		SubChannelChatClearUserMessages: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatClearUserMessages](),
+		},
+		SubChannelChatMessage: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatMessage](),
+		},
+		SubChannelChatMessageDelete: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatMessageDelete](),
+		},
+		SubChannelChatNotification: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatNotification](),
+		},
+		SubChannelChatSettingsUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChatSettingsUpdate](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -87,6 +87,7 @@ var (
 	SubChannelChatMessageDelete     EventSubscription = "channel.chat.message_delete"
 	SubChannelChatNotification      EventSubscription = "channel.chat.notification"
 	SubChannelChatSettingsUpdate    EventSubscription = "channel.chat_settings.update"
+	SubChannelSuspiciousUserMessage EventSubscription = "channel.suspicious_user.message"
 
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
@@ -316,6 +317,10 @@ var (
 		SubChannelChatSettingsUpdate: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelChatSettingsUpdate](),
+		},
+		SubChannelSuspiciousUserMessage: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelSuspiciousUserMessage](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -89,6 +89,10 @@ var (
 	SubChannelChatSettingsUpdate    EventSubscription = "channel.chat_settings.update"
 	SubChannelSuspiciousUserMessage EventSubscription = "channel.suspicious_user.message"
 
+	SubChannelSharedChatBegin  EventSubscription = "channel.shared_chat.begin"
+	SubChannelSharedChatUpdate EventSubscription = "channel.shared_chat.update"
+	SubChannelSharedChatEnd    EventSubscription = "channel.shared_chat.end"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -321,6 +325,18 @@ var (
 		SubChannelSuspiciousUserMessage: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelSuspiciousUserMessage](),
+		},
+		SubChannelSharedChatBegin: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelSharedChatBegin](),
+		},
+		SubChannelSharedChatUpdate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelSharedChatUpdate](),
+		},
+		SubChannelSharedChatEnd: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelSharedChatEnd](),
 		},
 	}
 )

--- a/testEvents.json
+++ b/testEvents.json
@@ -1269,6 +1269,18 @@
             ]
         }
     },
+    "channel.suspicious_user.update": {
+        "broadcaster_user_id": "1050263435",
+        "broadcaster_user_name": "77f111cbb75341449f5",
+        "broadcaster_user_login": "77f111cbb75341449f5",
+        "moderator_user_id": "1050263436",
+        "moderator_user_name": "29087e59dfc441968f6",
+        "moderator_user_login": "29087e59dfc441968f6",
+        "user_id": "1050263437",
+        "user_name": "06fbcc75952245c5a87",
+        "user_login": "06fbcc75952245c5a87",
+        "low_trust_status": "restricted"
+    },
     "channel.shared_chat.begin": {
         "session_id": "2b64a92a-dbb8-424e-b1c3-304423ba1b6f",
         "broadcaster_user_id": "1971641",

--- a/testEvents.json
+++ b/testEvents.json
@@ -974,77 +974,53 @@
     },
     "automod.message.hold": {
         "broadcaster_user_id": "1337",
-        "broadcaster_user_name": "blah",
-        "broadcaster_user_login": "blahblah",
-        "user_id": "456789012",
-        "user_name": "baduser",
-        "user_login": "baduserbla",
-        "message_id": "bad-message-id",
-        "message": "This is a bad message… ",
-        "level": 5,
-        "category": "aggressive",
-        "held_at": "2022-12-02T15:00:00.00Z",
-        "fragments": {
-            "emotes": [
+        "broadcaster_user_login": "broadcaster",
+        "broadcaster_user_name": "broadcaster",
+        "user_id": "85749836",
+        "user_login": "isabelcoolaf",
+        "user_name": "isabelcoolaf",
+        "message_id": "message-id",
+        "message": {
+            "text": "This is a bad message...",
+            "fragments": [
                 {
-                    "text": "badtextemote1",
-                    "id": "emote-123",
-                    "set-id": "set-emote-1"
-                },
-                {
-                    "text": "badtextemote2",
-                    "id": "emote-234",
-                    "set-id": "set-emote-2"
-                }
-            ],
-            "cheermotes": [
-                {
-                    "text": "badtextcheermote1",
-                    "amount": 1000,
-                    "prefix": "prefix",
-                    "tier": 1
+                    "type": "text",
+                    "text": "This is a bad message...",
+                    "cheermote": null,
+                    "emote": null
                 }
             ]
-        }
+        },
+        "category": "namecalling",
+        "level": 2,
+        "held_at": "2024-09-29T20:33:48.641725498Z"
     },
     "automod.message.update": {
-        "broadcaster_user_id": "1337",
-        "broadcaster_user_name": "blah",
-        "broadcaster_user_login": "blahblah",
-        "user_id": "456789012",
-        "user_name": "baduser",
-        "user_login": "baduserbla",
-        "moderator_user_id": "9001",
-        "moderator_user_login": "the_mod",
-        "moderator_user_name": "The_Mod",
-        "message_id": "bad-message-id",
-        "message": "This is a bad message… ",
-        "level": 5,
-        "category": "aggressive",
-        "status": "approved",
-        "held_at": "2022-12-02T15:00:00.00Z",
-        "fragments": {
-            "emotes": [
+        "broadcaster_user_id": "1234",
+        "broadcaster_user_login": "broadcaster",
+        "broadcaster_user_name": "broadcaster",
+        "user_id": "4321",
+        "user_login": "bad-user",
+        "user_name": "bad-user",
+        "moderator_user_id": "85749836",
+        "moderator_user_login": "isabelcoolaf",
+        "moderator_user_name": "isabelcoolaf",
+        "message_id": "message-id",
+        "message": {
+            "text": "This is a bad message...",
+            "fragments": [
                 {
-                    "text": "badtextemote1",
-                    "id": "emote-123",
-                    "set-id": "set-emote-1"
-                },
-                {
-                    "text": "badtextemote2",
-                    "id": "emote-234",
-                    "set-id": "set-emote-2"
-                }
-            ],
-            "cheermotes": [
-                {
-                    "text": "badtextcheermote1",
-                    "amount": 1000,
-                    "prefix": "prefix",
-                    "tier": 1
+                    "type": "text",
+                    "text": "This is a bad message...",
+                    "cheermote": null,
+                    "emote": null
                 }
             ]
-        }
+        },
+        "category": "namecalling",
+        "level": 2,
+        "status": "approved",
+        "held_at": "2024-09-29T21:06:15.199609857Z"
     },
     "automod.settings.update": {
         "broadcaster_user_id": "1337",

--- a/testEvents.json
+++ b/testEvents.json
@@ -962,7 +962,6 @@
         "cooldown_ends_at": "2022-07-26T17:02:03.17106713Z",
         "target_cooldown_ends_at": "2022-07-26T18:00:03.17106713Z"
     },
-    
     "channel.shoutout.receive": {
         "broadcaster_user_id": "626262",
         "broadcaster_user_name": "SandySanderman",
@@ -972,5 +971,111 @@
         "from_broadcaster_user_login": "simplysimple",
         "viewer_count": 860,
         "started_at": "2022-07-26T17:00:03.17106713Z"
+    },
+    "automod.message.hold": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "blah",
+        "broadcaster_user_login": "blahblah",
+        "user_id": "456789012",
+        "user_name": "baduser",
+        "user_login": "baduserbla",
+        "message_id": "bad-message-id",
+        "message": "This is a bad message… ",
+        "level": 5,
+        "category": "aggressive",
+        "held_at": "2022-12-02T15:00:00.00Z",
+        "fragments": {
+            "emotes": [
+                {
+                    "text": "badtextemote1",
+                    "id": "emote-123",
+                    "set-id": "set-emote-1"
+                },
+                {
+                    "text": "badtextemote2",
+                    "id": "emote-234",
+                    "set-id": "set-emote-2"
+                }
+            ],
+            "cheermotes": [
+                {
+                    "text": "badtextcheermote1",
+                    "amount": 1000,
+                    "prefix": "prefix",
+                    "tier": 1
+                }
+            ]
+        }
+    },
+    "automod.message.update": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "blah",
+        "broadcaster_user_login": "blahblah",
+        "user_id": "456789012",
+        "user_name": "baduser",
+        "user_login": "baduserbla",
+        "moderator_user_id": "9001",
+        "moderator_user_login": "the_mod",
+        "moderator_user_name": "The_Mod",
+        "message_id": "bad-message-id",
+        "message": "This is a bad message… ",
+        "level": 5,
+        "category": "aggressive",
+        "status": "approved",
+        "held_at": "2022-12-02T15:00:00.00Z",
+        "fragments": {
+            "emotes": [
+                {
+                    "text": "badtextemote1",
+                    "id": "emote-123",
+                    "set-id": "set-emote-1"
+                },
+                {
+                    "text": "badtextemote2",
+                    "id": "emote-234",
+                    "set-id": "set-emote-2"
+                }
+            ],
+            "cheermotes": [
+                {
+                    "text": "badtextcheermote1",
+                    "amount": 1000,
+                    "prefix": "prefix",
+                    "tier": 1
+                }
+            ]
+        }
+    },
+    "automod.settings.update": {
+        "data": [
+            {
+                "broadcaster_user_id": "1337",
+                "broadcaster_user_name": "CoolUser",
+                "broadcaster_user_login": "cooluser",
+                "moderator_user_id": "9001",
+                "moderator_user_name": "CoolMod",
+                "moderator_user_login": "coolmod",
+                "overall_level": null,
+                "disability": 3,
+                "aggression": 3,
+                "sexuality_sex_or_gender": 3,
+                "misogyny": 3,
+                "bullying": 3,
+                "swearing": 0,
+                "race_ethnicity_or_religion": 3,
+                "sex_based_terms":30
+            }
+        ]
+    },
+    "automod.terms.update": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "blah",
+        "broadcaster_user_login": "blahblah",
+        "moderator_user_id": "9001",
+        "moderator_user_login": "the_mod",
+        "moderator_user_name": "The_Mod",
+        "action": "add_blocked",
+        "from_automod": true,
+        "terms": ["automodterm1", "automodterm2", "automodterm3"]
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1090,5 +1090,141 @@
                 }
             ]
         }
+    },
+    "channel.chat.clear": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "Cool_User",
+        "broadcaster_user_login": "cool_user"
+    },
+    "channel.chat.clear_user_messages": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "Cool_User",
+        "broadcaster_user_login": "cool_user",
+        "target_user_id": "7734",
+        "target_user_name": "Uncool_viewer",
+        "target_user_login": "uncool_viewer"
+    },
+    "channel.chat.message": {
+        "broadcaster_user_id": "1971641",
+        "broadcaster_user_login": "streamer",
+        "broadcaster_user_name": "streamer",
+        "chatter_user_id": "4145994",
+        "chatter_user_login": "viewer32",
+        "chatter_user_name": "viewer32",
+        "message_id": "cc106a89-1814-919d-454c-f4f2f970aae7",
+        "message": {
+            "text": "Hi chat",
+            "fragments": [
+                {
+                    "type": "text",
+                    "text": "Hi chat",
+                    "cheermote": null,
+                    "emote": null,
+                    "mention": null
+                }
+            ]
+        },
+        "color": "#00FF7F",
+        "badges": [
+            {
+                "set_id": "moderator",
+                "id": "1",
+                "info": ""
+            },
+            {
+                "set_id": "subscriber",
+                "id": "12",
+                "info": "16"
+            },
+            {
+                "set_id": "sub-gifter",
+                "id": "1",
+                "info": ""
+            }
+        ],
+        "message_type": "text",
+        "cheer": null,
+        "reply": null,
+        "channel_points_custom_reward_id": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "source_message_id": null,
+        "source_badges": null
+    },
+    "channel.chat.message_delete": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "Cool_User",
+        "broadcaster_user_login": "cool_user",
+        "target_user_id": "7734",
+        "target_user_name": "Uncool_viewer",
+        "target_user_login": "uncool_viewer",
+        "message_id": "ab24e0b0-2260-4bac-94e4-05eedd4ecd0e"
+    },
+    "channel.chat.notification": {
+        "broadcaster_user_id": "1971641",
+        "broadcaster_user_login": "streamer",
+        "broadcaster_user_name": "streamer",
+        "chatter_user_id": "49912639",
+        "chatter_user_login": "viewer23",
+        "chatter_user_name": "viewer23",
+        "chatter_is_anonymous": false,
+        "color": "",
+        "badges": [],
+        "system_message": "viewer23 subscribed at Tier 1. They've subscribed for 10 months!",
+        "message_id": "d62235c8-47ff-a4f4--84e8-5a29a65a9c03",
+        "message": {
+            "text": "",
+            "fragments": []
+        },
+        "notice_type": "resub",
+        "sub": null,
+        "resub": {
+            "cumulative_months": 10,
+            "duration_months": 0,
+            "streak_months": null,
+            "sub_plan": "1000",
+            "is_gift": false,
+            "gifter_is_anonymous": null,
+            "gifter_user_id": null,
+            "gifter_user_name": null,
+            "gifter_user_login": null
+        },
+        "sub_gift": null,
+        "community_sub_gift": null,
+        "gift_paid_upgrade": null,
+        "prime_paid_upgrade": null,
+        "pay_it_forward": null,
+        "raid": null,
+        "unraid": null,
+        "announcement": null,
+        "bits_badge_tier": null,
+        "charity_donation": null,
+        "shared_chat_sub": null,
+        "shared_chat_resub": null,
+        "shared_chat_sub_gift": null,
+        "shared_chat_community_sub_gift": null,
+        "shared_chat_gift_paid_upgrade": null,
+        "shared_chat_prime_paid_upgrade": null,
+        "shared_chat_pay_it_forward": null,
+        "shared_chat_raid": null,
+        "shared_chat_announcement": null,
+        "source_broadcaster_user_id": null,
+        "source_broadcaster_user_login": null,
+        "source_broadcaster_user_name": null,
+        "source_message_id": null,
+        "source_badges": null
+    },
+    "channel.chat_settings.update": {
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cool_user",
+        "broadcaster_user_name": "Cool_User",
+        "emote_mode": true,
+        "follower_mode": false,
+        "follower_mode_duration_minutes": null,
+        "slow_mode": true,
+        "slow_mode_wait_time_seconds": 10,
+        "subscriber_mode": false,
+        "unique_chat_mode": false
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1324,5 +1324,17 @@
         "host_broadcaster_user_id": "1971641",
         "host_broadcaster_user_login": "streamer",
         "host_broadcaster_user_name": "streamer"
+    },
+    "user.whisper.message": {
+        "from_user_id": "423374343",
+        "from_user_login": "glowillig",
+        "from_user_name": "glowillig",
+        "to_user_id": "424596340",
+        "to_user_login": "quotrok",
+        "to_user_name": "quotrok",
+        "whisper_id": "some-whisper-id",
+        "whisper": {
+            "text": "a secret"
+        }
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1049,5 +1049,46 @@
         "action": "add_blocked",
         "from_automod": true,
         "terms": ["automodterm1", "automodterm2", "automodterm3"]
+    },
+    "channel.chat.user_message_hold": {
+        "broadcaster_user_id": "1234",
+        "broadcaster_user_login": "broadcaster",
+        "broadcaster_user_name": "broadcaster",
+        "user_id": "85749836",
+        "user_login": "isabelcoolaf",
+        "user_name": "isabelcoolaf",
+        "message_id": "message-id",
+        "message": {
+            "text": "This is a bad message...",
+            "fragments": [
+                {
+                    "type": "text",
+                    "text": "This is a bad message...",
+                    "cheermote": null,
+                    "emote": null
+                }
+            ]
+        }
+    },
+    "channel.chat.user_message_update": {
+        "broadcaster_user_id": "1234",
+        "broadcaster_user_login": "broadcaster",
+        "broadcaster_user_name": "broadcaster",
+        "user_id": "85749836",
+        "user_login": "isabelcoolaf",
+        "user_name": "isabelcoolaf",
+        "status": "approved",
+        "message_id": "message-id",
+        "message": {
+            "text": "This is a bad message...",
+            "fragments": [
+                {
+                    "type": "text",
+                    "text": "This is a bad message...",
+                    "cheermote": null,
+                    "emote": null
+                }
+            ]
+        }
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1268,5 +1268,61 @@
                 }
             ]
         }
+    },
+    "channel.shared_chat.begin": {
+        "session_id": "2b64a92a-dbb8-424e-b1c3-304423ba1b6f",
+        "broadcaster_user_id": "1971641",
+        "broadcaster_user_login": "streamer",
+        "broadcaster_user_name": "streamer",
+        "host_broadcaster_user_id": "1971641",
+        "host_broadcaster_user_login": "streamer",
+        "host_broadcaster_user_name": "streamer",
+        "participants": [
+            {
+                "broadcaster_user_id": "1971641",
+                "broadcaster_user_name": "streamer",
+                "broadcaster_user_login": "streamer"
+            },
+            {
+                "broadcaster_user_id": "112233",
+                "broadcaster_user_name": "streamer33",
+                "broadcaster_user_login": "streamer33"
+            }
+        ]
+    },
+    "channel.shared_chat.update": {
+        "session_id": "2b64a92a-dbb8-424e-b1c3-304423ba1b6f",
+        "broadcaster_user_id": "1971641",
+        "broadcaster_user_login": "streamer",
+        "broadcaster_user_name": "streamer",
+        "host_broadcaster_user_id": "1971641",
+        "host_broadcaster_user_login": "streamer",
+        "host_broadcaster_user_name": "streamer",
+        "participants": [
+            {
+                "broadcaster_user_id": "1971641",
+                "broadcaster_user_name": "streamer",
+                "broadcaster_user_login": "streamer"
+            },
+            {
+                "broadcaster_user_id": "112233",
+                "broadcaster_user_name": "streamer33",
+                "broadcaster_user_login": "streamer33"
+            },
+            {
+                "broadcaster_user_id": "332211",
+                "broadcaster_user_name": "streamer11",
+                "broadcaster_user_login": "streamer11"
+            }
+        ]
+    },
+    "channel.shared_chat.end": {
+        "session_id": "2b64a92a-dbb8-424e-b1c3-304423ba1b6f",
+        "broadcaster_user_id": "1971641",
+        "broadcaster_user_login": "streamer",
+        "broadcaster_user_name": "streamer",
+        "host_broadcaster_user_id": "1971641",
+        "host_broadcaster_user_login": "streamer",
+        "host_broadcaster_user_name": "streamer"
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1226,5 +1226,47 @@
         "slow_mode_wait_time_seconds": 10,
         "subscriber_mode": false,
         "unique_chat_mode": false
+    },
+    "channel.suspicious_user.message": {
+        "broadcaster_user_id": "1050263432",
+        "broadcaster_user_name": "dcf9dd9336034d23b65",
+        "broadcaster_user_login": "dcf9dd9336034d23b65",
+        "user_id": "1050263434",
+        "user_name": "4a46e2cf2e2f4d6a9e6",
+        "user_login": "4a46e2cf2e2f4d6a9e6",
+        "low_trust_status": "active_monitoring",
+        "shared_ban_channel_ids": [
+            "100",
+            "200"
+        ],
+        "types": [
+            "ban_evader"
+        ],
+        "ban_evasion_evaluation": "likely",
+        "message": {
+            "message_id": "101010",
+            "text": "bad stuff pogchamp",
+            "fragments": [
+                {
+                    "type": "emote",
+                    "text": "bad stuff",
+                    "cheermote": null,
+                    "emote": {
+                        "id": "899",
+                        "emote_set_id": "1"
+                    }
+                },
+                {
+                    "type": "cheermote",
+                    "text": "pogchamp",
+                    "cheermote": {
+                        "prefix": "pogchamp",
+                        "bits": 100,
+                        "tier": 1
+                    },
+                    "emote": null
+                }
+            ]
+        }
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1047,25 +1047,21 @@
         }
     },
     "automod.settings.update": {
-        "data": [
-            {
-                "broadcaster_user_id": "1337",
-                "broadcaster_user_name": "CoolUser",
-                "broadcaster_user_login": "cooluser",
-                "moderator_user_id": "9001",
-                "moderator_user_name": "CoolMod",
-                "moderator_user_login": "coolmod",
-                "overall_level": null,
-                "disability": 3,
-                "aggression": 3,
-                "sexuality_sex_or_gender": 3,
-                "misogyny": 3,
-                "bullying": 3,
-                "swearing": 0,
-                "race_ethnicity_or_religion": 3,
-                "sex_based_terms":30
-            }
-        ]
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_name": "CoolUser",
+        "broadcaster_user_login": "cooluser",
+        "moderator_user_id": "9001",
+        "moderator_user_name": "CoolMod",
+        "moderator_user_login": "coolmod",
+        "overall_level": null,
+        "disability": 3,
+        "aggression": 3,
+        "sexuality_sex_or_gender": 3,
+        "misogyny": 3,
+        "bullying": 3,
+        "swearing": 0,
+        "race_ethnicity_or_religion": 3,
+        "sex_based_terms": 30
     },
     "automod.terms.update": {
         "broadcaster_user_id": "1337",


### PR DESCRIPTION
This PR adds support for these EventSub subscription types:
- automod.message.hold
- automod.message.update
- automod.settings.update
- automod.terms.update
- channel.chat.user_message_hold
- channel.chat.user_message_update
- channel.chat.clear
- channel.chat.clear_user_messages
- channel.chat.message
- channel.chat.message_delete
- channel.chat.notification
- channel.chat_settings.update
- channel.suspicious_user.message
- channel.suspicious_user.update
- channel.shared_chat.begin
- channel.shared_chat.update
- channel.shared_chat.end
- user.whisper.message

This PR effectively implements all of Twitch's recent changes to EventSub as it relates to chatting.
Apologies for the large PR, but I figured it would be good to bundle all the chat-related types together as the majority of them follow the same ChatMessage structure introduced in EventSub.

I left alone channel.moderate because there is already a pretty good PR for that one: #7 

I fully tested each subscription type using the library on live Twitch, and the code also passes the "example" tests. It will work exactly how you expect it to.
Do note, for a couple of the tests I wrote my own example instead of one from the docs because the docs were incorrect on one or two of them. Those examples follow the structure exactly as I received it from Twitch in my own testing.

Please let me know if there are any concerns and I will address them promptly.
Thanks :)