### PR TITLE
Add new channel subscription types

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -106,6 +106,8 @@ type Client struct {
 	onEventChannelShoutoutCreate                            func(event EventChannelShoutoutCreate)
 	onEventChannelShoutoutReceive                           func(event EventChannelShoutoutReceive)
 	onEventChannelAdBreakBegin                              func(event EventChannelAdBreakBegin)
+	onEventChannelWarningAcknowledge                        func(event EventChannelWarningAcknowledge)
+	onEventChannelWarningSend                               func(event EventChannelWarningSend)
 }
 
 func NewClient() *Client {
@@ -381,6 +383,10 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelShoutoutReceive, *event)
 	case *EventChannelAdBreakBegin:
 		callFunc(c.onEventChannelAdBreakBegin, *event)
+	case *EventChannelWarningAcknowledge:
+		callFunc(c.onEventChannelWarningAcknowledge, *event)
+	case *EventChannelWarningSend:
+		callFunc(c.onEventChannelWarningSend, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -632,4 +638,12 @@ func (c *Client) OnEventChannelShoutoutReceive(callback func(event EventChannelS
 
 func (c *Client) OnEventChannelAdBreakBegin(callback func(event EventChannelAdBreakBegin)) {
 	c.onEventChannelAdBreakBegin = callback
+}
+
+func (c *Client) OnEventChannelWarningAcknowledge(callback func(event EventChannelWarningAcknowledge)) {
+	c.onEventChannelWarningAcknowledge = callback
+}
+
+func (c *Client) OnEventChannelWarningSend(callback func(event EventChannelWarningSend)) {
+	c.onEventChannelWarningSend = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -69,6 +69,8 @@ type Client struct {
 	onEventChannelUnban                                     func(event EventChannelUnban)
 	onEventChannelModeratorAdd                              func(event EventChannelModeratorAdd)
 	onEventChannelModeratorRemove                           func(event EventChannelModeratorRemove)
+	onEventChannelVIPAdd                                    func(event EventChannelVIPAdd)
+	onEventChannelVIPRemove                                 func(event EventChannelVIPRemove)
 	onEventChannelChannelPointsCustomRewardAdd              func(event EventChannelChannelPointsCustomRewardAdd)
 	onEventChannelChannelPointsCustomRewardUpdate           func(event EventChannelChannelPointsCustomRewardUpdate)
 	onEventChannelChannelPointsCustomRewardRemove           func(event EventChannelChannelPointsCustomRewardRemove)
@@ -305,6 +307,10 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelModeratorAdd, *event)
 	case *EventChannelModeratorRemove:
 		callFunc(c.onEventChannelModeratorRemove, *event)
+	case *EventChannelVIPAdd:
+		callFunc(c.onEventChannelVIPAdd, *event)
+	case *EventChannelVIPRemove:
+		callFunc(c.onEventChannelVIPRemove, *event)
 	case *EventChannelChannelPointsCustomRewardAdd:
 		callFunc(c.onEventChannelChannelPointsCustomRewardAdd, *event)
 	case *EventChannelChannelPointsCustomRewardUpdate:
@@ -478,6 +484,14 @@ func (c *Client) OnEventChannelModeratorAdd(callback func(event EventChannelMode
 
 func (c *Client) OnEventChannelModeratorRemove(callback func(event EventChannelModeratorRemove)) {
 	c.onEventChannelModeratorRemove = callback
+}
+
+func (c *Client) OnEventChannelVIPAdd(callback func(event EventChannelVIPAdd)) {
+	c.onEventChannelVIPAdd = callback
+}
+
+func (c *Client) OnEventChannelVIPRemove(callback func(event EventChannelVIPRemove)) {
+	c.onEventChannelVIPRemove = callback
 }
 
 func (c *Client) OnEventChannelChannelPointsCustomRewardAdd(callback func(event EventChannelChannelPointsCustomRewardAdd)) {

--- a/conn.go
+++ b/conn.go
@@ -108,6 +108,8 @@ type Client struct {
 	onEventChannelAdBreakBegin                              func(event EventChannelAdBreakBegin)
 	onEventChannelWarningAcknowledge                        func(event EventChannelWarningAcknowledge)
 	onEventChannelWarningSend                               func(event EventChannelWarningSend)
+	onEventChannelUnbanRequestCreate                        func(event EventChannelUnbanRequestCreate)
+	onEventChannelUnbanRequestResolve                       func(event EventChannelUnbanRequestResolve)
 }
 
 func NewClient() *Client {
@@ -387,6 +389,10 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelWarningAcknowledge, *event)
 	case *EventChannelWarningSend:
 		callFunc(c.onEventChannelWarningSend, *event)
+	case *EventChannelUnbanRequestCreate:
+		callFunc(c.onEventChannelUnbanRequestCreate, *event)
+	case *EventChannelUnbanRequestResolve:
+		callFunc(c.onEventChannelUnbanRequestResolve, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -646,4 +652,12 @@ func (c *Client) OnEventChannelWarningAcknowledge(callback func(event EventChann
 
 func (c *Client) OnEventChannelWarningSend(callback func(event EventChannelWarningSend)) {
 	c.onEventChannelWarningSend = callback
+}
+
+func (c *Client) OnEventChannelUnbanRequestCreate(callback func(event EventChannelUnbanRequestCreate)) {
+	c.onEventChannelUnbanRequestCreate = callback
+}
+
+func (c *Client) OnEventChannelUnbanRequestResolve(callback func(event EventChannelUnbanRequestResolve)) {
+	c.onEventChannelUnbanRequestResolve = callback
 }

--- a/conn.go
+++ b/conn.go
@@ -74,6 +74,7 @@ type Client struct {
 	onEventChannelChannelPointsCustomRewardRemove           func(event EventChannelChannelPointsCustomRewardRemove)
 	onEventChannelChannelPointsCustomRewardRedemptionAdd    func(event EventChannelChannelPointsCustomRewardRedemptionAdd)
 	onEventChannelChannelPointsCustomRewardRedemptionUpdate func(event EventChannelChannelPointsCustomRewardRedemptionUpdate)
+	onEventChannelChannelPointsAutomaticRewardRedemptionAdd func(event EventChannelChannelPointsAutomaticRewardRedemptionAdd)
 	onEventChannelPollBegin                                 func(event EventChannelPollBegin)
 	onEventChannelPollProgress                              func(event EventChannelPollProgress)
 	onEventChannelPollEnd                                   func(event EventChannelPollEnd)
@@ -314,6 +315,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelChannelPointsCustomRewardRedemptionAdd, *event)
 	case *EventChannelChannelPointsCustomRewardRedemptionUpdate:
 		callFunc(c.onEventChannelChannelPointsCustomRewardRedemptionUpdate, *event)
+	case *EventChannelChannelPointsAutomaticRewardRedemptionAdd:
+		callFunc(c.onEventChannelChannelPointsAutomaticRewardRedemptionAdd, *event)
 	case *EventChannelPollBegin:
 		callFunc(c.onEventChannelPollBegin, *event)
 	case *EventChannelPollProgress:
@@ -495,6 +498,10 @@ func (c *Client) OnEventChannelChannelPointsCustomRewardRedemptionAdd(callback f
 
 func (c *Client) OnEventChannelChannelPointsCustomRewardRedemptionUpdate(callback func(event EventChannelChannelPointsCustomRewardRedemptionUpdate)) {
 	c.onEventChannelChannelPointsCustomRewardRedemptionUpdate = callback
+}
+
+func (c *Client) OnEventChannelChannelPointsAutomaticRewardRedemptionAdd(callback func(event EventChannelChannelPointsAutomaticRewardRedemptionAdd)) {
+	c.onEventChannelChannelPointsAutomaticRewardRedemptionAdd = callback
 }
 
 func (c *Client) OnEventChannelPollBegin(callback func(event EventChannelPollBegin)) {

--- a/conn.go
+++ b/conn.go
@@ -102,6 +102,7 @@ type Client struct {
 	onEventChannelShieldModeEnd                             func(event EventChannelShieldModeEnd)
 	onEventChannelShoutoutCreate                            func(event EventChannelShoutoutCreate)
 	onEventChannelShoutoutReceive                           func(event EventChannelShoutoutReceive)
+	onEventChannelAdBreakBegin                              func(event EventChannelAdBreakBegin)
 }
 
 func NewClient() *Client {
@@ -369,6 +370,8 @@ func (c *Client) handleNotification(message NotificationMessage) error {
 		callFunc(c.onEventChannelShoutoutCreate, *event)
 	case *EventChannelShoutoutReceive:
 		callFunc(c.onEventChannelShoutoutReceive, *event)
+	case *EventChannelAdBreakBegin:
+		callFunc(c.onEventChannelAdBreakBegin, *event)
 	default:
 		c.onError(fmt.Errorf("unknown event type %s", subscription.Type))
 	}
@@ -604,4 +607,8 @@ func (c *Client) OnEventChannelShoutoutCreate(callback func(event EventChannelSh
 
 func (c *Client) OnEventChannelShoutoutReceive(callback func(event EventChannelShoutoutReceive)) {
 	c.onEventChannelShoutoutReceive = callback
+}
+
+func (c *Client) OnEventChannelAdBreakBegin(callback func(event EventChannelAdBreakBegin)) {
+	c.onEventChannelAdBreakBegin = callback
 }

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -184,6 +184,26 @@ func TestEventChannelModeratorRemove(t *testing.T) {
 	}, twitch.SubChannelModeratorRemove)
 }
 
+func TestEventChannelVIPAdd(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelVIPAdd(func(event twitch.EventChannelVIPAdd) {
+			close(ch)
+		})
+	}, twitch.SubChannelVIPAdd)
+}
+
+func TestEventChannelVIPRemove(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelVIPRemove(func(event twitch.EventChannelVIPRemove) {
+			close(ch)
+		})
+	}, twitch.SubChannelVIPRemove)
+}
+
 func TestEventChannelChannelPointsCustomRewardAdd(t *testing.T) {
 	t.Parallel()
 

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -573,3 +573,24 @@ func TestEventChannelAdBreakBegin(t *testing.T) {
 		})
 	}, twitch.SubChannelAdBreakBegin)
 }
+
+func TestEventChannelWarningAcknowledge(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelWarningAcknowledge(func(event twitch.EventChannelWarningAcknowledge) {
+			close(ch)
+		})
+	}, twitch.SubChannelWarningAcknowledge)
+}
+
+func TestEventChannelWarningSend(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelWarningSend(func(event twitch.EventChannelWarningSend) {
+			close(ch)
+		})
+	}, twitch.SubChannelWarningSend)
+
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -533,3 +533,13 @@ func TestEventChannelShoutoutReceive(t *testing.T) {
 		})
 	}, twitch.SubChannelShoutoutReceive)
 }
+
+func TestEventChannelAdBreakBegin(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelAdBreakBegin(func(event twitch.EventChannelAdBreakBegin) {
+			close(ch)
+		})
+	}, twitch.SubChannelAdBreakBegin)
+}

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -592,5 +592,24 @@ func TestEventChannelWarningSend(t *testing.T) {
 			close(ch)
 		})
 	}, twitch.SubChannelWarningSend)
+}
 
+func TestEventChannelUnbanRequestCreate(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelUnbanRequestCreate(func(event twitch.EventChannelUnbanRequestCreate) {
+			close(ch)
+		})
+	}, twitch.SubChannelUnbanRequestCreate)
+}
+
+func TestEventChannelUnbanRequestResolve(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelUnbanRequestResolve(func(event twitch.EventChannelUnbanRequestResolve) {
+			close(ch)
+		})
+	}, twitch.SubChannelUnbanRequestResolve)
 }

--- a/connEvent_test.go
+++ b/connEvent_test.go
@@ -234,6 +234,16 @@ func TestEventChannelChannelPointsCustomRewardRedemptionUpdate(t *testing.T) {
 	}, twitch.SubChannelChannelPointsCustomRewardRedemptionUpdate)
 }
 
+func TestEventChannelChannelPointsAutomaticRewardRedemptionAdd(t *testing.T) {
+	t.Parallel()
+
+	assertSpecificEventOccured(t, func(client *twitch.Client, ch chan struct{}) {
+		client.OnEventChannelChannelPointsAutomaticRewardRedemptionAdd(func(event twitch.EventChannelChannelPointsAutomaticRewardRedemptionAdd) {
+			close(ch)
+		})
+	}, twitch.SubChannelChannelPointsAutomaticRewardRedemptionAdd)
+}
+
 func TestEventChannelPollBegin(t *testing.T) {
 	t.Parallel()
 

--- a/events.go
+++ b/events.go
@@ -134,6 +134,16 @@ type EventChannelModeratorRemove struct {
 	User
 }
 
+type EventChannelVIPAdd struct {
+	Broadcaster
+	User
+}
+
+type EventChannelVIPRemove struct {
+	Broadcaster
+	User
+}
+
 type MaxChannelPointsPerStream struct {
 	IsEnabled bool `json:"is_enabled"`
 	Value     int  `json:"value"`

--- a/events.go
+++ b/events.go
@@ -507,3 +507,17 @@ type EventChannelAdBreakBegin struct {
 	RequesterUserLogin string    `json:"requester_user_login"`
 	RequesterUserName  string    `json:"requester_user_name"`
 }
+
+type EventChannelWarningAcknowledge struct {
+	Broadcaster
+	User
+}
+
+type EventChannelWarningSend struct {
+	Broadcaster
+	Moderator
+	User
+
+	Reason         string   `json:"reason"`
+	ChatRulesCited []string `json:"chat_rules_cited"`
+}

--- a/events.go
+++ b/events.go
@@ -464,3 +464,14 @@ type EventChannelShoutoutReceive struct {
 	ViewerCount              int       `json:"viewer_count"`
 	StartedAt                time.Time `json:"started_at"`
 }
+
+type EventChannelAdBreakBegin struct {
+	Broadcaster
+
+	DurationSeconds    int       `json:"duration_seconds"`
+	StartedAt          time.Time `json:"started_at"`
+	IsAutomatic        bool      `json:"is_automatic"`
+	RequesterUserId    string    `json:"requester_user_id"`
+	RequesterUserLogin string    `json:"requester_user_login"`
+	RequesterUserName  string    `json:"requester_user_name"`
+}

--- a/events.go
+++ b/events.go
@@ -521,3 +521,22 @@ type EventChannelWarningSend struct {
 	Reason         string   `json:"reason"`
 	ChatRulesCited []string `json:"chat_rules_cited"`
 }
+
+type EventChannelUnbanRequestCreate struct {
+	Broadcaster
+	User
+
+	Id        string    `json:"id"`
+	Text      string    `json:"text"`
+	CreatedAt time.Time `json:"created_at"`
+}
+
+type EventChannelUnbanRequestResolve struct {
+	Broadcaster
+	Moderator
+	User
+
+	Id             string `json:"id"`
+	ResolutionText string `json:"resolution_text"`
+	Status         string `json:"status"`
+}

--- a/events.go
+++ b/events.go
@@ -176,7 +176,7 @@ type EventChannelChannelPointsCustomRewardUpdate EventChannelChannelPointsCustom
 
 type EventChannelChannelPointsCustomRewardRemove EventChannelChannelPointsCustomRewardAdd
 
-type ChannelPointReward struct {
+type CustomChannelPointReward struct {
 	ID     string `json:"id"`
 	Title  string `json:"title"`
 	Cost   int    `json:"cost"`
@@ -187,14 +187,36 @@ type EventChannelChannelPointsCustomRewardRedemptionAdd struct {
 	Broadcaster
 	User
 
-	ID         string             `json:"id"`
-	UserInput  string             `json:"user_input"`
-	Status     string             `json:"status"`
-	Reward     ChannelPointReward `json:"reward"`
-	RedeemedAt time.Time          `json:"redeemed_at"`
+	ID         string                   `json:"id"`
+	UserInput  string                   `json:"user_input"`
+	Status     string                   `json:"status"`
+	Reward     CustomChannelPointReward `json:"reward"`
+	RedeemedAt time.Time                `json:"redeemed_at"`
 }
 
 type EventChannelChannelPointsCustomRewardRedemptionUpdate EventChannelChannelPointsCustomRewardRedemptionAdd
+
+type AutomaticChannelPointRewardUnlockedEmote struct {
+	ID   string `json:"id"`
+	Name string `json:"name"`
+}
+
+type AutomaticChannelPointReward struct {
+	Type          string                                    `json:"type"`
+	Cost          int                                       `json:"cost"`
+	UnlockedEmote *AutomaticChannelPointRewardUnlockedEmote `json:"unlocked_emote"`
+}
+
+type EventChannelChannelPointsAutomaticRewardRedemptionAdd struct {
+	Broadcaster
+	User
+
+	ID         string                      `json:"id"`
+	Reward     AutomaticChannelPointReward `json:"reward"`
+	Message    Message                     `json:"message"`
+	UserInput  string                      `json:"user_input"`
+	RedeemedAt time.Time                   `json:"redeemed_at"`
+}
 
 type PollChoice struct {
 	ID                string `json:"id"`

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -79,6 +79,9 @@ var (
 
 	SubChannelAdBreakBegin EventSubscription = "channel.ad_break.begin"
 
+	SubChannelWarningAcknowledge EventSubscription = "channel.warning.acknowledge"
+	SubChannelWarningSend        EventSubscription = "channel.warning.send"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -275,6 +278,14 @@ var (
 		SubChannelAdBreakBegin: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelAdBreakBegin](),
+		},
+		SubChannelWarningAcknowledge: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelWarningAcknowledge](),
+		},
+		SubChannelWarningSend: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelWarningSend](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -29,6 +29,8 @@ var (
 
 	SubChannelModeratorAdd    EventSubscription = "channel.moderator.add"
 	SubChannelModeratorRemove EventSubscription = "channel.moderator.remove"
+	SubChannelVIPAdd          EventSubscription = "channel.vip.add"
+	SubChannelVIPRemove       EventSubscription = "channel.vip.remove"
 
 	SubChannelChannelPointsCustomRewardAdd              EventSubscription = "channel.channel_points_custom_reward.add"
 	SubChannelChannelPointsCustomRewardUpdate           EventSubscription = "channel.channel_points_custom_reward.update"
@@ -125,6 +127,14 @@ var (
 		SubChannelModeratorRemove: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelModeratorRemove](),
+		},
+		SubChannelVIPAdd: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelVIPAdd](),
+		},
+		SubChannelVIPRemove: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelVIPRemove](),
 		},
 		SubChannelChannelPointsCustomRewardAdd: {
 			Version:  "1",

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -74,6 +74,8 @@ var (
 	SubChannelShoutoutCreate  EventSubscription = "channel.shoutout.create"
 	SubChannelShoutoutReceive EventSubscription = "channel.shoutout.receive"
 
+	SubChannelAdBreakBegin EventSubscription = "channel.ad_break.begin"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -254,6 +256,10 @@ var (
 		SubChannelShoutoutReceive: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelShoutoutReceive](),
+		},
+		SubChannelAdBreakBegin: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelAdBreakBegin](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -82,6 +82,9 @@ var (
 	SubChannelWarningAcknowledge EventSubscription = "channel.warning.acknowledge"
 	SubChannelWarningSend        EventSubscription = "channel.warning.send"
 
+	SubChannelUnbanRequestCreate  EventSubscription = "channel.unban_request.create"
+	SubChannelUnbanRequestResolve EventSubscription = "channel.unban_request.resolve"
+
 	subMetadata = map[EventSubscription]subscriptionMetadata{
 		SubChannelUpdate: {
 			Version:  "2",
@@ -286,6 +289,14 @@ var (
 		SubChannelWarningSend: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelWarningSend](),
+		},
+		SubChannelUnbanRequestCreate: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelUnbanRequestCreate](),
+		},
+		SubChannelUnbanRequestResolve: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelUnbanRequestResolve](),
 		},
 	}
 )

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -35,6 +35,7 @@ var (
 	SubChannelChannelPointsCustomRewardRemove           EventSubscription = "channel.channel_points_custom_reward.remove"
 	SubChannelChannelPointsCustomRewardRedemptionAdd    EventSubscription = "channel.channel_points_custom_reward_redemption.add"
 	SubChannelChannelPointsCustomRewardRedemptionUpdate EventSubscription = "channel.channel_points_custom_reward_redemption.update"
+	SubChannelChannelPointsAutomaticRewardRedemptionAdd EventSubscription = "channel.channel_points_automatic_reward_redemption.add"
 
 	SubChannelPollBegin    EventSubscription = "channel.poll.begin"
 	SubChannelPollProgress EventSubscription = "channel.poll.progress"
@@ -144,6 +145,10 @@ var (
 		SubChannelChannelPointsCustomRewardRedemptionUpdate: {
 			Version:  "1",
 			EventGen: zeroPtrGen[EventChannelChannelPointsCustomRewardRedemptionUpdate](),
+		},
+		SubChannelChannelPointsAutomaticRewardRedemptionAdd: {
+			Version:  "1",
+			EventGen: zeroPtrGen[EventChannelChannelPointsAutomaticRewardRedemptionAdd](),
 		},
 		SubChannelPollBegin: {
 			Version:  "1",

--- a/testEvents.json
+++ b/testEvents.json
@@ -1045,5 +1045,30 @@
         "user_name": "TwitchDev",
         "reason": "cut it out",
         "chat_rules_cited": null
+    },
+    "channel.unban_request.create": {
+        "id": "60",
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cool_user",
+        "broadcaster_user_name": "Cool_User",
+        "user_id": "1339",
+        "user_login": "not_cool_user",
+        "user_name": "Not_Cool_User",
+        "text": "unban me",
+        "created_at": "2023-11-16T10:11:12.634234626Z"
+    },
+    "channel.unban_request.resolve": {
+        "id": "60",
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cool_user",
+        "broadcaster_user_name": "Cool_User",
+        "moderator_user_id": "1337",
+        "moderator_user_login": "cool_user",
+        "moderator_user_name": "Cool_User",
+        "user_id": "1339",
+        "user_login": "not_cool_user",
+        "user_name": "Not_Cool_User",
+        "resolution_text": "no",
+        "status": "denied"
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -1024,5 +1024,26 @@
         "requester_user_id": "1337",
         "requester_user_login": "cool_user",
         "requester_user_name": "Cool_User"
+    },
+    "channel.warning.acknowledge": {
+        "broadcaster_user_id": "423374343",
+        "broadcaster_user_login": "glowillig",
+        "broadcaster_user_name": "glowillig",
+        "user_id": "141981764",
+        "user_login": "twitchdev",
+        "user_name": "TwitchDev"
+    },
+    "channel.warning.send": {
+        "broadcaster_user_id": "423374343",
+        "broadcaster_user_login": "glowillig",
+        "broadcaster_user_name": "glowillig",
+        "moderator_user_id": "424596340",
+        "moderator_user_login": "quotrok",
+        "moderator_user_name": "quotrok",
+        "user_id": "141981764",
+        "user_login": "twitchdev",
+        "user_name": "TwitchDev",
+        "reason": "cut it out",
+        "chat_rules_cited": null
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -973,9 +973,9 @@
         "started_at": "2022-07-26T17:00:03.17106713Z"
     },
     "channel.ad_break.begin": {
-        "duration_seconds": "60",
+        "duration_seconds": 60,
         "started_at": "2019-11-16T10:11:12.634234626Z",
-        "is_automatic": "false",
+        "is_automatic": false,
         "broadcaster_user_id": "1337",
         "broadcaster_user_login": "cool_user",
         "broadcaster_user_name": "Cool_User",

--- a/testEvents.json
+++ b/testEvents.json
@@ -962,7 +962,6 @@
         "cooldown_ends_at": "2022-07-26T17:02:03.17106713Z",
         "target_cooldown_ends_at": "2022-07-26T18:00:03.17106713Z"
     },
-    
     "channel.shoutout.receive": {
         "broadcaster_user_id": "626262",
         "broadcaster_user_name": "SandySanderman",
@@ -972,5 +971,16 @@
         "from_broadcaster_user_login": "simplysimple",
         "viewer_count": 860,
         "started_at": "2022-07-26T17:00:03.17106713Z"
+    },
+    "channel.ad_break.begin": {
+        "duration_seconds": "60",
+        "started_at": "2019-11-16T10:11:12.634234626Z",
+        "is_automatic": "false",
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cool_user",
+        "broadcaster_user_name": "Cool_User",
+        "requester_user_id": "1337",
+        "requester_user_login": "cool_user",
+        "requester_user_name": "Cool_User"
     }
 }

--- a/testEvents.json
+++ b/testEvents.json
@@ -333,6 +333,32 @@
         },
         "redeemed_at": "2020-07-15T17:16:03.17106713Z"
     },
+    "channel.channel_points_automatic_reward_redemption.add": {
+        "broadcaster_user_id": "12826",
+        "broadcaster_user_name": "Twitch",
+        "broadcaster_user_login": "twitch",
+        "user_id": "141981764",
+        "user_name": "TwitchDev",
+        "user_login": "twitchdev",
+        "id": "f024099a-e0fe-4339-9a0a-a706fb59f353",
+        "reward": {
+            "type": "send_highlighted_message",
+            "cost": 100,
+            "unlocked_emote": null
+        },
+        "message": {
+            "text": "Hello world! VoHiYo",
+            "emotes": [
+                {
+                    "id": "81274",
+                    "begin": 13,
+                    "end": 18
+                }
+            ]
+        },
+        "user_input": "Hello world! VoHiYo ",
+        "redeemed_at": "2024-02-23T21:14:34.260398045Z"
+    },
     "channel.poll.begin": {
         "id": "1243456",
         "broadcaster_user_id": "1337",

--- a/testEvents.json
+++ b/testEvents.json
@@ -180,6 +180,22 @@
         "broadcaster_user_login": "cooler_user",
         "broadcaster_user_name": "Cooler_User"
     },
+    "channel.vip.add": {
+        "user_id": "1234",
+        "user_login": "vip_user",
+        "user_name": "VIP_User",
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cooler_user",
+        "broadcaster_user_name": "Cooler_User"
+    },
+    "channel.vip.remove": {
+        "user_id": "1234",
+        "user_login": "not_vip_user",
+        "user_name": "Not_VIP_User",
+        "broadcaster_user_id": "1337",
+        "broadcaster_user_login": "cooler_user",
+        "broadcaster_user_name": "Cooler_User"
+    },
     "channel.channel_points_custom_reward.add": {
         "id": "9001",
         "broadcaster_user_id": "1337",


### PR DESCRIPTION
This PR adds support for these EventSub subscription types:
- channel.ad_break.begin
- channel.unban_request.create
- channel.unban_request.resolve
- channel.channel_points_automatic_reward_redemption.add
- channel.vip.add
- channel.vip.remove
- channel.warning.acknowledge
- channel.warning.send

This PR implements the rest of the new channel. EventSub subscription types.
As I stated in my other PR, I left alone channel.moderate because there is already a pretty good PR for that one: #7 

I fully tested each subscription type using the library on live Twitch, and the code also passes the "example" tests. It will work exactly how you expect it to.

Please let me know if there are any concerns and I will address them promptly.
Thanks :)